### PR TITLE
Remove mytile_discover_table_existence

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -163,7 +163,6 @@ static int mytile_init_func(void *p) {
   // Set table discovery functions
   mytile_hton->discover_table_structure = tile::mytile_discover_table_structure;
   mytile_hton->discover_table = tile::mytile_discover_table;
-  mytile_hton->discover_table_existence = tile::mytile_discover_table_existence;
 
   DBUG_RETURN(0);
 }

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -206,18 +206,3 @@ int tile::discover_array(handlerton *hton, THD *thd, TABLE_SHARE *ts,
   // discover_table should returns HA_ERR_NO_SUCH_TABLE for "not exists"
   DBUG_RETURN(res == ENOENT ? HA_ERR_NO_SUCH_TABLE : res);
 }
-
-int tile::mytile_discover_table_existence(handlerton *hton, const char *db,
-                                          const char *name) {
-
-  DBUG_ENTER("tile::mytile_discover_table_existence");
-  try {
-    tiledb::Context ctx;
-    std::string uri = name;
-    tiledb::ArraySchema schema(ctx, uri);
-  } catch (tiledb::TileDBError &e) {
-    DBUG_RETURN(false);
-  }
-
-  DBUG_RETURN(true);
-}

--- a/mytile/mytile-discovery.h
+++ b/mytile/mytile-discovery.h
@@ -69,13 +69,4 @@ int mytile_discover_table_structure(handlerton *hton, THD *thd,
  */
 int mytile_discover_table(handlerton *hton, THD *thd, TABLE_SHARE *ts);
 
-/**
- * Checks if an array exists or not
- * @param hton
- * @param db
- * @param name
- * @return
- */
-int mytile_discover_table_existence(handlerton *hton, const char *db,
-                                    const char *name);
 } // namespace tile


### PR DESCRIPTION
This function did not correctly check if an array exists. Without
defining this function mariadb will just fall back to a full table
discovery which is handled more robustly.