### PR TITLE
Support user set tiledb config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ There are three parameters currently supported for MyTile.
 | read_buffer_size | global or session | integer | 100M | Read buffer size for tiledb query attribute/coordinates |
 | write_buffer_size | global or session | integer | 100M | Write buffer size for tiledb query attribute/coordinates |
 | delete_arrays | global or session | boolean | False | Controls if a `delete table` statement causes the array to be deleted on disk or just deregistered from mariadb. True value causes actual deletions of data |
+| tiledb_config* | global or session | string | "" | Set tiledb configuration parameters, this is in csv form of `key1=value1,key2=value2`. Example: `set mytile_tiledb_config = 'vfs.s3.aws_access_key_id=abc,vfs.s3.aws_secret_access_key=123';` |
+
+
+\* TileDB config is only set on handler creation or table opening. If you change parameters for a table that is open
+(such as one recently accessed) then you will need to first `FLUSH TABLES` before the new configuration parameters
+will take effect.
 
 ## Features
 

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -87,11 +87,11 @@ public:
    * @param name
    * @param table_arg
    * @param create_info
-   * @param ctx
+   * @param context
    * @return
    */
   int create_array(const char *name, TABLE *table_arg,
-                   HA_CREATE_INFO *create_info, tiledb::Context ctx);
+                   HA_CREATE_INFO *create_info, tiledb::Context context);
 
   /**
    * Drop a table
@@ -355,6 +355,7 @@ private:
    * Helper function which validates the array is open for reads
    */
   void open_array_for_reads();
+
   /**
    * Helper function which validates the array is open for writes
    */

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -54,7 +54,8 @@ int tile::discover_array(handlerton *hton, THD *thd, TABLE_SHARE *ts,
                          HA_CREATE_INFO *info) {
   DBUG_ENTER("tile::discover_array");
   std::stringstream sql_string;
-  tiledb::Context ctx;
+  tiledb::Config config = build_config(thd);
+  tiledb::Context ctx(config);
   std::string array_uri;
   std::unique_ptr<tiledb::ArraySchema> schema;
 

--- a/mytile/mytile.h
+++ b/mytile/mytile.h
@@ -352,7 +352,6 @@ int set_buffer_from_field(T val, std::shared_ptr<buffer> &buff, uint64_t i) {
 
 int set_buffer_from_field(Field *field, std::shared_ptr<buffer> &buff,
                           uint64_t i, THD *thd);
-
 // -- end helpers --
 
 } // namespace tile

--- a/mytile/utils.cc
+++ b/mytile/utils.cc
@@ -1,5 +1,5 @@
 /**
- * @file   mytile-sysvars.h
+ * @file   utils.h
  *
  * @section LICENSE
  *
@@ -27,39 +27,46 @@
  *
  * @section DESCRIPTION
  *
- * This declares the system variables for the storage engine
+ * Contains utility functions
  */
 
-#pragma once
+#include "utils.h"
+#include <string>
+#include <vector>
+#include <sstream>
+#include <sql_class.h>
 
-#ifndef MYTILE_SYSVARS_H
-#define MYTILE_SYSVARS_H
+/**
+ *
+ * Split a string by delimeter
+ *
+ * @param str string to split
+ * @param delim delimeter to split by
+ * @return vector of split strings
+ */
+std::vector<std::string> tile::split(const std::string &str, char delim) {
+  std::vector<std::string> res;
+  std::stringstream ss(str);
+  std::string token;
+  while (std::getline(ss, token, delim)) {
+    res.push_back(token);
+  }
+  return res;
+}
 
-#include <handler.h>
-#include <my_global.h>
+/**
+ * compares two config
+ * @param rhs
+ * @param lhs
+ * @return true is identical, false otherwise
+ */
+bool tile::compare_configs(tiledb::Config &rhs, tiledb::Config &lhs) {
+  // Check every parameter to see if they are the same or different
+  for (auto it : rhs) {
+    if (lhs.get(it.first) != it.second) {
+      return false;
+    }
+  }
 
-// list of system parameters
-extern struct st_mysql_sys_var *mytile_system_variables[];
-
-// Read buffer size
-static MYSQL_THDVAR_ULONGLONG(
-    read_buffer_size, PLUGIN_VAR_OPCMDARG,
-    "Read buffer size per attribute for tiledb queries", NULL, NULL, 104857600,
-    0, ~0UL, 0);
-
-// Write buffer size
-static MYSQL_THDVAR_ULONGLONG(
-    write_buffer_size, PLUGIN_VAR_OPCMDARG,
-    "Write buffer size per attribute for tiledb queries", NULL, NULL, 104857600,
-    0, ~0UL, 0);
-
-// Physically delete arrays
-static MYSQL_THDVAR_BOOL(delete_arrays, PLUGIN_VAR_OPCMDARG,
-                         "Should drop table delete tiledb arrays", NULL, NULL,
-                         false);
-
-static MYSQL_THDVAR_STR(tiledb_config,
-                        PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_MEMALLOC,
-                        "TileDB configuration parameters, comma separated",
-                        NULL, NULL, "");
-#endif // MYTILE_SYSVARS_H
+  return true;
+}

--- a/mytile/utils.h
+++ b/mytile/utils.h
@@ -31,6 +31,15 @@
  */
 
 #pragma once
+
+#define MYSQL_SERVER 1
+
+#include <string>
+#include <algorithm>
+#include <tiledb/tiledb>
+#include "my_global.h" /* ulonglong */
+#include <handler.h>
+
 namespace tile {
 const char PATH_SEPARATOR =
 #ifdef _WIN32
@@ -58,4 +67,32 @@ static inline void trim(std::string &s) {
   ltrim(s);
   rtrim(s);
 }
+
+/**
+ *
+ * Split a string by delimeter
+ *
+ * @param str string to split
+ * @param delim delimeter to split by
+ * @return vector of split strings
+ */
+std::vector<std::string> split(const std::string &str, char delim = ',');
+
+/**
+ *
+ * Fetches the tiledb_config server/session parameter and builds a tiledb config
+ * object
+ *
+ * @param thd
+ * @return config with any parameters set
+ */
+tiledb::Config build_config(THD *thd);
+
+/**
+ * compares two config
+ * @param rhs
+ * @param lhs
+ * @return true is identical, false otherwise
+ */
+bool compare_configs(tiledb::Config &rhs, tiledb::Config &lhs);
 } // namespace tile


### PR DESCRIPTION
This adds a new server and session variable `mytile_tiledb_config` which is a csv list of parameters in the form `key1=value1,key2=value2`.

A helper function is also added for creating the tiledb config objects and for splitting a delimited string.

The TileDB config is only set on handler creation or table opening. If you change parameters for a table that is open (such as one recently accessed) then you will need to first `FLUSH TABLES` before the new configuration parameters will take effect.

This was tested by using the `vfs.s3.aws_access_key_id` and `vfs.s3.aws_secret_access_key` to access remote arrays.