### PR TITLE
Don't preinit the server docker and other misc fixes for server docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 build
 cmake-build-debug
 cmake-build-release
-Dockerfile
-Dockerfile-dev
-Dockerfile-interactive
+docker/Dockerfile
+docker/Dockerfile-dev
+docker/Dockerfile-interactive
 .git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.0.4"
+ARG MYTILE_VERSION="0.0.5"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -131,6 +131,10 @@ RUN chown -R mysql:mysql /opt/tiledb_arrays
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
 
 ENV MYSQL_DATABASE=test
+
+# Set paths needed for bitnami helm mariadb
+RUN mkdir /opt/bitnami
+RUN ln -s /opt/server /opt/bitnami/mariadb
 
 # Setup initial DB for faster starts
 RUN /tmp/init.sh "mysqld"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.0.3"
+ARG MYTILE_VERSION="0.0.4"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -52,6 +52,15 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
+# Install tiledb using 1.6 release
+RUN mkdir build_deps && cd build_deps \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.6.3 && cd TileDB \
+ && mkdir -p build && cd build \
+ && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
+ && make -j$(nproc) \
+ && make -C tiledb install \
+ && cd /tmp && rm -r build_deps
+
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
 ADD . /tmp/mytile
@@ -62,20 +71,14 @@ RUN cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-# Install tiledb using 1.6 release
-RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.6.3 && cd TileDB \
- && mkdir -p build && cd build \
- && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
- && make -j$(nproc) \
- && make -C tiledb install \
- && cd /tmp && rm -r build_deps
-
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \
  && cp /tmp/mytile/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN cp /tmp/mytile/docker/init.sh /tmp/init.sh
+
+ENV CFLAGS "${CFLAGS} -Wno-error=noexcept-type"
+ENV CXXFLAGS "${CXXFLAGS} -Wno-error=noexcept-type"
 
 RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
@@ -83,7 +86,7 @@ RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${
   && cd ${MARIADB_VERSION} \
   && mkdir builddir \
   && cd builddir \
-  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
+  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=DEBUG -SWITH_DEBUG=1 -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
   && cd ../../ \
@@ -128,6 +131,10 @@ RUN chown -R mysql:mysql /opt/tiledb_arrays
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
 
 ENV MYSQL_DATABASE=test
+
+# Set paths needed for bitnami helm mariadb
+RUN mkdir /opt/bitnami
+RUN ln -s /opt/server /opt/bitnami/mariadb
 
 USER mysql
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -129,9 +129,6 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
 
 ENV MYSQL_DATABASE=test
 
-# Setup initial DB for faster starts
-RUN /tmp/init.sh mysqld
-
 USER mysql
 
 EXPOSE 3306

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -54,7 +54,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.0.3"
+ARG MYTILE_VERSION="0.0.4"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -128,14 +128,6 @@ RUN chown -R mysql:mysql /var/log/mysql
 RUN chown -R mysql:mysql /opt/server
 
 RUN chown -R mysql:mysql /opt/tiledb_arrays
-
-# Set defaults for initializing the server
-ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
-
-ENV MYSQL_DATABASE=test
-
-# Setup initial DB for faster starts
-RUN /tmp/init.sh mysqld
 
 USER mysql
 

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -54,7 +54,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.0.4"
+ARG MYTILE_VERSION="0.0.5"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -128,6 +128,10 @@ RUN chown -R mysql:mysql /var/log/mysql
 RUN chown -R mysql:mysql /opt/server
 
 RUN chown -R mysql:mysql /opt/tiledb_arrays
+
+# Set paths needed for bitnami helm mariadb
+RUN mkdir /opt/bitnami
+RUN ln -s /opt/server /opt/bitnami/mariadb
 
 USER mysql
 

--- a/docker/docker-entrypoint-interactive.sh
+++ b/docker/docker-entrypoint-interactive.sh
@@ -18,6 +18,37 @@ for arg; do
 	esac
 done
 
+
+# Support both MARIADB_ and MYSQL_ parameters
+# Docker expects one, helm another so lets do both
+if [ ! -z "$MARIADB_ROOT_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_ALLOW_EMPTY_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_ALLOW_EMPTY_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_RANDOM_ROOT_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_USER" ]; then
+    export MYSQL_USER=${MARIADB_USER}
+fi
+
+if [ ! -z "$MARIADB_USERNAME" ]; then
+    export MYSQL_USER=${MARIADB_USERNAME}
+fi
+
+if [ ! -z "$MARIADB_PASSWORD" ]; then
+    export MYSQL_PASSWORD=${MARIADB_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_DATABASE" ]; then
+    export MYSQL_DATABASE=${MARIADB_DATABASE}
+fi
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -18,6 +18,36 @@ for arg; do
 	esac
 done
 
+# Support both MARIADB_ and MYSQL_ parameters
+# Docker expects one, helm another so lets do both
+if [ ! -z "$MARIADB_ROOT_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_ALLOW_EMPTY_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_ALLOW_EMPTY_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_RANDOM_ROOT_PASSWORD" ]; then
+    export MYSQL_ROOT_PASSWORD=${MARIADB_RANDOM_ROOT_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_USER" ]; then
+    export MYSQL_USER=${MARIADB_USER}
+fi
+
+if [ ! -z "$MARIADB_USERNAME" ]; then
+    export MYSQL_USER=${MARIADB_USERNAME}
+fi
+
+if [ ! -z "$MARIADB_PASSWORD" ]; then
+    export MYSQL_PASSWORD=${MARIADB_PASSWORD}
+fi
+
+if [ ! -z "$MARIADB_DATABASE" ]; then
+    export MYSQL_DATABASE=${MARIADB_DATABASE}
+fi
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of


### PR DESCRIPTION
This makes the tiledb-mariadb-sever version behave like regular mariadb docker image and makes it compatible with the helm mariadb chart for k8s.