### PR TITLE
Always make sure to set all buffers for writes

### DIFF
--- a/mysql-test/mytile/r/insert_into_select.result
+++ b/mysql-test/mytile/r/insert_into_select.result
@@ -1,0 +1,11 @@
+#
+# The purpose of this test is to test insert into select statements
+#
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 tile_extent=100, `cols` INTEGER DIMENSION=1 tile_extent=100, a INTEGER unsigned) ENGINE=MyTile;
+FLUSH TABLES;
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+DROP TABLE quickstart_dense_2;
+set mytile_delete_arrays=0;
+DROP TABLE `quickstart_dense`;
+set mytile_delete_arrays=1;

--- a/mysql-test/mytile/t/insert_into_select.test
+++ b/mysql-test/mytile/t/insert_into_select.test
@@ -1,0 +1,18 @@
+--echo #
+--echo # The purpose of this test is to test insert into select statements
+--echo #
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 tile_extent=100, `cols` INTEGER DIMENSION=1 tile_extent=100, a INTEGER unsigned) ENGINE=MyTile;
+
+FLUSH TABLES;
+
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+
+DROP TABLE quickstart_dense_2;
+
+set mytile_delete_arrays=0;
+DROP TABLE `quickstart_dense`;
+set mytile_delete_arrays=1;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1191,8 +1191,7 @@ void tile::mytile::setup_write() {
   DBUG_ENTER("tile::mytile::setup_write");
   // We must set the bitmap for debug purpose, it is "read_set" because we use
   // Field->val_*
-  my_bitmap_map *original_bitmap =
-      dbug_tmp_use_all_columns(table, table->read_set);
+  my_bitmap_map *original_bitmap = tmp_use_all_columns(table, table->read_set);
   this->write_buffer_size = THDVAR(this->ha_thd(), write_buffer_size);
   alloc_buffers(this->write_buffer_size);
   this->record_index = 0;
@@ -1203,7 +1202,7 @@ void tile::mytile::setup_write() {
     buff->offset_buffer_size = 0;
   }
   // Reset bitmap to original
-  dbug_tmp_restore_column_map(table->read_set, original_bitmap);
+  tmp_restore_column_map(table->read_set, original_bitmap);
   DBUG_VOID_RETURN;
 }
 
@@ -1321,8 +1320,7 @@ int tile::mytile::write_row(const uchar *buf) {
   int rc = 0;
   // We must set the bitmap for debug purpose, it is "read_set" because we use
   // Field->val_*
-  my_bitmap_map *original_bitmap =
-      dbug_tmp_use_all_columns(table, table->read_set);
+  my_bitmap_map *original_bitmap = tmp_use_all_columns(table, table->read_set);
 
   open_array_for_writes();
 
@@ -1336,7 +1334,7 @@ int tile::mytile::write_row(const uchar *buf) {
       flush_write();
 
       // Reset bitmap to original
-      dbug_tmp_restore_column_map(table->read_set, original_bitmap);
+      tmp_restore_column_map(table->read_set, original_bitmap);
       DBUG_RETURN(write_row(buf));
     }
     this->record_index++;
@@ -1358,7 +1356,7 @@ int tile::mytile::write_row(const uchar *buf) {
   }
 
   // Reset bitmap to original
-  dbug_tmp_restore_column_map(table->read_set, original_bitmap);
+  tmp_restore_column_map(table->read_set, original_bitmap);
   DBUG_RETURN(rc);
 }
 


### PR DESCRIPTION
We switch on the bitmap for readset for creating buffers, so we need to make sure its set to all fields. Previously we used `dbug_tmp_use_all_columns` but this only sets it when built in debug mode.
Instead we should use `tmp_user_all_columns`;

It is "read_set" because we use the Field->val_* accessors. So we "read" values from the server into a "tiledb write".