### PR TITLE
Support reloading tiledb config for every query

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,11 @@ There are three parameters currently supported for MyTile.
 | read_buffer_size | global or session | integer | 100M | Read buffer size for tiledb query attribute/coordinates |
 | write_buffer_size | global or session | integer | 100M | Write buffer size for tiledb query attribute/coordinates |
 | delete_arrays | global or session | boolean | False | Controls if a `delete table` statement causes the array to be deleted on disk or just deregistered from mariadb. True value causes actual deletions of data |
-| tiledb_config* | global or session | string | "" | Set tiledb configuration parameters, this is in csv form of `key1=value1,key2=value2`. Example: `set mytile_tiledb_config = 'vfs.s3.aws_access_key_id=abc,vfs.s3.aws_secret_access_key=123';` |
+| tiledb_config* | global or session | string | "" | Set TileDB configuration parameters, this is in csv form of `key1=value1,key2=value2`. Example: `set mytile_tiledb_config = 'vfs.s3.aws_access_key_id=abc,vfs.s3.aws_secret_access_key=123';` |
+| reopen_for_every_query | global or session | boolean | True | Closes and reopen the array for every query, this allows tiledb_config parameters to take effect without forcing a table flush but any tiledb caching is removed. |
 
-
-\* TileDB config is only set on handler creation or table opening. If you change parameters for a table that is open
-(such as one recently accessed) then you will need to first `FLUSH TABLES` before the new configuration parameters
-will take effect.
+\* If reopen_for_every_query is disabled you must `FLUSH TABLES` before any new parameters set on `tiledb_config`
+will take effect on an open array (recently access arrays are not closed by MariaDB immediately).
 
 ## Features
 

--- a/mysql-test/mytile/r/flushing_arrays.result
+++ b/mysql-test/mytile/r/flushing_arrays.result
@@ -1,0 +1,58 @@
+#
+# The purpose of this test is to validate mytile_reopen_for_every_query for both true and false settings
+#
+# Setup existing array first
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+# Create test array
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 tile_extent=100, `cols` INTEGER DIMENSION=1 tile_extent=100, a INTEGER unsigned) ENGINE=MyTile;
+# Start with no tables open
+FLUSH TABLES;
+# Test with mytile_reopen_for_every_query=1
+set mytile_reopen_for_every_query = 1;
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+select * from quickstart_dense_2;
+rows	cols	a
+1	1	1
+1	2	2
+1	3	3
+1	4	4
+2	1	5
+2	2	6
+2	3	7
+2	4	8
+3	1	9
+3	2	10
+3	3	11
+3	4	12
+4	1	13
+4	2	14
+4	3	15
+4	4	16
+# Close all tables between queries
+FLUSH TABLES;
+# Test with mytile_reopen_for_every_query=0
+set mytile_reopen_for_every_query = 0;
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+select * from quickstart_dense_2;
+rows	cols	a
+1	1	1
+1	2	2
+1	3	3
+1	4	4
+2	1	5
+2	2	6
+2	3	7
+2	4	8
+3	1	9
+3	2	10
+3	3	11
+3	4	12
+4	1	13
+4	2	14
+4	3	15
+4	4	16
+# Cleanup
+DROP TABLE quickstart_dense_2;
+set mytile_delete_arrays=0;
+DROP TABLE `quickstart_dense`;
+set mytile_delete_arrays=1;

--- a/mysql-test/mytile/t/flushing_arrays.test
+++ b/mysql-test/mytile/t/flushing_arrays.test
@@ -1,0 +1,33 @@
+--echo #
+--echo # The purpose of this test is to validate mytile_reopen_for_every_query for both true and false settings
+--echo #
+
+--echo # Setup existing array first
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+
+--echo # Create test array
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 tile_extent=100, `cols` INTEGER DIMENSION=1 tile_extent=100, a INTEGER unsigned) ENGINE=MyTile;
+
+--echo # Start with no tables open
+FLUSH TABLES;
+
+--echo # Test with mytile_reopen_for_every_query=1
+set mytile_reopen_for_every_query = 1;
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+select * from quickstart_dense_2;
+
+--echo # Close all tables between queries
+FLUSH TABLES;
+
+--echo # Test with mytile_reopen_for_every_query=0
+set mytile_reopen_for_every_query = 0;
+INSERT INTO quickstart_dense_2 (`rows`, `cols`, `a`) SELECT `rows`, `cols`, `a` FROM  (select * from quickstart_dense) q1;
+select * from quickstart_dense_2;
+
+--echo # Cleanup
+DROP TABLE quickstart_dense_2;
+set mytile_delete_arrays=0;
+DROP TABLE `quickstart_dense`;
+set mytile_delete_arrays=1;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -354,11 +354,11 @@ private:
   /**
    * Helper function which validates the array is open for reads
    */
-  void open_array_for_reads();
+  void open_array_for_reads(THD *thd);
 
   /**
    * Helper function which validates the array is open for writes
    */
-  void open_array_for_writes();
+  void open_array_for_writes(THD *thd);
 };
 } // namespace tile

--- a/mytile/mytile-sysvars.h
+++ b/mytile/mytile-sysvars.h
@@ -44,22 +44,30 @@ extern struct st_mysql_sys_var *mytile_system_variables[];
 // Read buffer size
 static MYSQL_THDVAR_ULONGLONG(
     read_buffer_size, PLUGIN_VAR_OPCMDARG,
-    "Read buffer size per attribute for tiledb queries", NULL, NULL, 104857600,
+    "Read buffer size per attribute for TileDB queries", NULL, NULL, 104857600,
     0, ~0UL, 0);
 
 // Write buffer size
 static MYSQL_THDVAR_ULONGLONG(
     write_buffer_size, PLUGIN_VAR_OPCMDARG,
-    "Write buffer size per attribute for tiledb queries", NULL, NULL, 104857600,
+    "Write buffer size per attribute for TileDB queries", NULL, NULL, 104857600,
     0, ~0UL, 0);
 
 // Physically delete arrays
 static MYSQL_THDVAR_BOOL(delete_arrays, PLUGIN_VAR_OPCMDARG,
-                         "Should drop table delete tiledb arrays", NULL, NULL,
+                         "Should drop table delete TileDB arrays", NULL, NULL,
                          false);
-
+// Set TileDB Configuration parameters
 static MYSQL_THDVAR_STR(tiledb_config,
                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_MEMALLOC,
                         "TileDB configuration parameters, comma separated",
                         NULL, NULL, "");
+
+// Should arrays force to be reopened? This allows for new TileDB Configuration
+// parameters to always take effect
+static MYSQL_THDVAR_BOOL(
+    reopen_for_every_query, PLUGIN_VAR_OPCMDARG,
+    "Force reopen TileDB array for every query, this allows for tiledb_config "
+    "paraneters to always take effect",
+    NULL, NULL, true);
 #endif // MYTILE_SYSVARS_H


### PR DESCRIPTION
A new configuration open is given reopen_for_every_query to disable this new behavior. Forcing arrays to be reopened is required to allow TileDB configuration parameters to take effect without flushing tables. Flushing tables is a blocking operation so it might not be desired.

The downside of reopening the arrays by creating new contexts is that any caching or in memory fragments are lost.