### PR TITLE
Load array schema and store as unique_ptr

### DIFF
--- a/mysql-test/mytile/r/pushdown_ranges.result
+++ b/mysql-test/mytile/r/pushdown_ranges.result
@@ -1,0 +1,22 @@
+#
+# The purpose of this test is to validate pushed ranges
+#
+# INTEGER
+CREATE TABLE t1 (
+column1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+column2 BLOB
+) ENGINE=mytile;
+INSERT INTO t1 VALUES (1,'aHR0cHM6Ly9naXRodWIuY29tL1NoZWxudXR0Mi9jcnVuY2g=');
+INSERT INTO t1 VALUES (3,'dmFsdWUy');
+INSERT INTO t1 VALUES (5,'dmFsdWU');
+select column1, column2 FROM t1 WHERE column1 = 3;
+column1	column2
+3	dmFsdWUy
+select column2 FROM t1 WHERE column1 IN (1,3);
+column2
+aHR0cHM6Ly9naXRodWIuY29tL1NoZWxudXR0Mi9jcnVuY2g=
+dmFsdWUy
+select * FROM t1 WHERE column2 = 'dmFsdWU';
+column1	column2
+5	dmFsdWU
+DROP TABLE t1;

--- a/mysql-test/mytile/t/pushdown_ranges.test
+++ b/mysql-test/mytile/t/pushdown_ranges.test
@@ -1,0 +1,18 @@
+--echo #
+--echo # The purpose of this test is to validate pushed ranges
+--echo #
+--echo # INTEGER
+
+CREATE TABLE t1 (
+  column1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  column2 BLOB
+) ENGINE=mytile;
+INSERT INTO t1 VALUES (1,'aHR0cHM6Ly9naXRodWIuY29tL1NoZWxudXR0Mi9jcnVuY2g=');
+INSERT INTO t1 VALUES (3,'dmFsdWUy');
+INSERT INTO t1 VALUES (5,'dmFsdWU');
+select column1, column2 FROM t1 WHERE column1 = 3;
+select column2 FROM t1 WHERE column1 IN (1,3);
+select * FROM t1 WHERE column2 = 'dmFsdWU';
+
+
+DROP TABLE t1;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -321,6 +321,9 @@ private:
   // Number of dimensions, this is used frequently so let's cache it
   uint64_t ndim = 0;
 
+  // Array Schema
+  std::unique_ptr<tiledb::ArraySchema> array_schema;
+
   // Upper bound for number of records so we know stopping condition
   uint64_t total_num_records_UB = 0;
 
@@ -360,5 +363,11 @@ private:
    * Helper function which validates the array is open for writes
    */
   void open_array_for_writes(THD *thd);
+
+  /**
+   * Checks if there are any ranges pushed
+   * @return
+   */
+  bool valid_pushed_ranges();
 };
 } // namespace tile


### PR DESCRIPTION
This fixes cond_push with reopen_for_every_query, where there is more than one cond_push call. We don't want to reopen the array for each pushdown.

Also fixes handling determining if pushdowns are valid or not.