### PR TITLE
Don't build tiledb in verbose mode for non-dev docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.1.1"
+ARG MYTILE_VERSION="0.2.2"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -74,7 +74,7 @@ RUN git config --global user.email "you@example.com" \
 RUN mkdir build_deps && cd build_deps \
  && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
  && mkdir -p build && cd build \
- && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
+ && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \
  && make -C tiledb install \
  && cd /tmp && rm -r build_deps

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.8"
 
-ARG MYTILE_VERSION="0.1.1"
+ARG MYTILE_VERSION="0.2.2"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -74,7 +74,7 @@ RUN git config --global user.email "you@example.com" \
 RUN mkdir build_deps && cd build_deps \
  && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
  && mkdir -p build && cd build \
- && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
+ && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \
  && make -C tiledb install \
  && cd /tmp && rm -r build_deps


### PR DESCRIPTION
Don't use verbose mode for tiledb with docker images.