### PR TITLE
Don't access ha_th() on handler constructor

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -246,11 +246,7 @@ int tile::mytile::external_lock(THD *thd, int lock_type) {
  * @param table_arg
  */
 tile::mytile::mytile(handlerton *hton, TABLE_SHARE *table_arg)
-    : handler(hton, table_arg) {
-  this->config = build_config(ha_thd());
-
-  this->ctx = build_context(config);
-};
+    : handler(hton, table_arg){};
 
 /**
  * Create a table structure and TileDB array schema
@@ -262,6 +258,13 @@ tile::mytile::mytile(handlerton *hton, TABLE_SHARE *table_arg)
 int tile::mytile::create(const char *name, TABLE *table_arg,
                          HA_CREATE_INFO *create_info) {
   DBUG_ENTER("tile::mytile::create");
+  // First rebuild context with new config if needed
+  tiledb::Config cfg = build_config(ha_thd());
+
+  if (!compare_configs(cfg, this->config)) {
+    this->config = cfg;
+    this->ctx = build_context(this->config);
+  }
   DBUG_RETURN(create_array(name, table_arg, create_info, this->ctx));
 }
 

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -55,7 +55,7 @@ int tile::discover_array(handlerton *hton, THD *thd, TABLE_SHARE *ts,
   DBUG_ENTER("tile::discover_array");
   std::stringstream sql_string;
   tiledb::Config config = build_config(thd);
-  tiledb::Context ctx(config);
+  tiledb::Context ctx = build_context(config);
   std::string array_uri;
   std::unique_ptr<tiledb::ArraySchema> schema;
 

--- a/mytile/utils.cc
+++ b/mytile/utils.cc
@@ -62,8 +62,12 @@ std::vector<std::string> tile::split(const std::string &str, char delim) {
  */
 bool tile::compare_configs(tiledb::Config &rhs, tiledb::Config &lhs) {
   // Check every parameter to see if they are the same or different
-  for (auto it : rhs) {
-    if (lhs.get(it.first) != it.second) {
+  for (auto &it : rhs) {
+    try {
+      if (lhs.get(it.first) != it.second) {
+        return false;
+      }
+    } catch (tiledb::TileDBError &e) {
       return false;
     }
   }


### PR DESCRIPTION
This might have been causing the segfault on OSX with conda env. We don't actually need to create the config or ctx in the constructor so we can call it from member functions if needed.