### PR TITLE
Validate range values are non-nullptr

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1522,7 +1522,7 @@ bool tile::mytile::valid_pushed_ranges() {
   for (auto &range : this->pushdown_ranges) {
     if (!range.empty()) {
       for (auto &range_ptr : range) {
-        if (range_ptr != nullptr) {
+        if (range_ptr != nullptr && (range_ptr->lower_value != nullptr || range_ptr->upper_value != nullptr)) {
           one_valid_range = true;
         }
       }
@@ -1541,7 +1541,7 @@ bool tile::mytile::valid_pushed_in_ranges() {
   for (auto &range : this->pushdown_in_ranges) {
     if (!range.empty()) {
       for (auto &range_ptr : range) {
-        if (range_ptr != nullptr) {
+        if (range_ptr != nullptr && (range_ptr->lower_value != nullptr || range_ptr->upper_value != nullptr)) {
           one_valid_range = true;
         }
       }


### PR DESCRIPTION
When checking that the range pushdowns are valid we need to not just make sure they are non-empty but also that atleast one of the lower or upper values is set and non null.