### PR TITLE
Add support for Multi-Range-Reads (MRR) and Index Improvements

### DIFF
--- a/mysql-test/mytile/r/join.result
+++ b/mysql-test/mytile/r/join.result
@@ -1,0 +1,56 @@
+#
+# The purpose of this test is to validate the Index and Non Index Joins
+#
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+# Block Nested Loop Join Explain with Index
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+rows	cols	a	a
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	5	5
+2	2	6	6
+2	3	7	7
+2	4	8	8
+3	1	9	9
+3	2	10	10
+3	3	11	11
+3	4	12	12
+4	1	13	13
+4	2	14	14
+4	3	15	15
+4	4	16	16
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;
+set mytile_dimensions_are_primary_keys=0;
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+# Block Nested Loop Join Explain
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	2	Using where; Using join buffer (flat, BNL join)
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+rows	cols	a	a
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	5	5
+2	2	6	6
+2	3	7	7
+2	4	8	8
+3	1	9	9
+3	2	10	10
+3	3	11	11
+3	4	12	12
+4	1	13	13
+4	2	14	14
+4	3	15	15
+4	4	16	16
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;

--- a/mysql-test/mytile/r/mrr.result
+++ b/mysql-test/mytile/r/mrr.result
@@ -1,0 +1,61 @@
+#
+# The purpose of this test is to validate the MRR functionality
+#
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+# Block Nested Loop Join Explain
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	
+# Batch Key Access Join Explain
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=6;
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join); Key-ordered scan
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+rows	cols	a	a
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	5	5
+2	2	6	6
+2	3	7	7
+2	4	8	8
+3	1	9	9
+3	2	10	10
+3	3	11	11
+3	4	12	12
+4	1	13	13
+4	2	14	14
+4	3	15	15
+4	4	16	16
+# Batch Key Access Hash Join Explain
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=8;
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKAH join); Key-ordered scan
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+rows	cols	a	a
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	5	5
+2	2	6	6
+2	3	7	7
+2	4	8	8
+3	1	9	9
+3	2	10	10
+3	3	11	11
+3	4	12	12
+4	1	13	13
+4	2	14	14
+4	3	15	15
+4	4	16	16
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;

--- a/mysql-test/mytile/t/join.test
+++ b/mysql-test/mytile/t/join.test
@@ -1,0 +1,30 @@
+--echo #
+--echo # The purpose of this test is to validate the Index and Non Index Joins
+--echo #
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+--echo # Block Nested Loop Join Explain with Index
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+# Run join
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+# Drop table to retry join without keys
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;
+
+set mytile_dimensions_are_primary_keys=0;
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+--echo # Block Nested Loop Join Explain
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+# Run join
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;

--- a/mysql-test/mytile/t/mrr.test
+++ b/mysql-test/mytile/t/mrr.test
@@ -1,0 +1,28 @@
+--echo #
+--echo # The purpose of this test is to validate the MRR functionality
+--echo #
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+--echo # Block Nested Loop Join Explain
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+--echo # Batch Key Access Join Explain
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=6;
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+# Run join
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+--echo # Batch Key Access Hash Join Explain
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=8;
+explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+# Run join
+select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
+
+set mytile_delete_arrays=0;
+drop table `quickstart_dense`;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1422,15 +1422,15 @@ bool tile::mytile::valid_pushed_ranges() {
   if (this->pushdown_ranges.empty())
     return false;
 
-  // Check all ranges and makes sure that atleast one is non empty and non null
+  // Check all dimensions and makes sure that atleast one is non empty and non
+  // null
   bool one_valid_range = false;
-  for (auto &range : this->pushdown_ranges) {
+  for (const auto &range : this->pushdown_ranges) {
     if (!range.empty()) {
-      for (auto &range_ptr : range) {
-        if (range_ptr != nullptr && (range_ptr->lower_value != nullptr ||
-                                     range_ptr->upper_value != nullptr)) {
-          one_valid_range = true;
-        }
+      const auto &range_ptr = range[0];
+      if (range_ptr != nullptr && (range_ptr->lower_value != nullptr ||
+                                   range_ptr->upper_value != nullptr)) {
+        return true;
       }
     }
   }
@@ -1442,15 +1442,15 @@ bool tile::mytile::valid_pushed_in_ranges() {
   if (this->pushdown_in_ranges.empty())
     return false;
 
-  // Check all ranges and makes sure that atleast one is non empty and non null
+  // Check all dimensions and makes sure that atleast one is non empty and non
+  // null
   bool one_valid_range = false;
-  for (auto &range : this->pushdown_in_ranges) {
+  for (const auto &range : this->pushdown_in_ranges) {
     if (!range.empty()) {
-      for (auto &range_ptr : range) {
-        if (range_ptr != nullptr && (range_ptr->lower_value != nullptr ||
-                                     range_ptr->upper_value != nullptr)) {
-          one_valid_range = true;
-        }
+      const auto &range_ptr = range[0];
+      if (range_ptr != nullptr && (range_ptr->lower_value != nullptr ||
+                                   range_ptr->upper_value != nullptr)) {
+        return true;
       }
     }
   }

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -384,6 +384,9 @@ int tile::mytile::init_scan(
   this->read_buffer_size = tile::sysvars::read_buffer_size(thd);
 
   try {
+    // Always reset query object so we make sure no ranges are left set
+    this->query = nullptr;
+
     // Validate the array is open for reads
     open_array_for_reads(thd);
 

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1483,7 +1483,8 @@ int tile::mytile::index_read(uchar *buf, const uchar *key, uint key_len,
   DBUG_ENTER("tile::mytile::index_read_map");
   // If no conditions or index have been pushed, use key scan info to push a
   // range down
-  if (!this->valid_pushed_ranges() && !this->valid_pushed_in_ranges()) {
+  if ((!this->valid_pushed_ranges() && !this->valid_pushed_in_ranges()) ||
+      this->query_complete()) {
     this->reset_pushdowns_for_key(key, key_len, find_flag);
     int rc = init_scan(
         this->ha_thd(),

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -414,14 +414,16 @@ int tile::mytile::init_scan(
       if (empty)
         DBUG_RETURN(HA_ERR_END_OF_FILE);
 
-      sql_print_information("no pushdowns possible for query");
+      sql_print_information("no pushdowns possible for query on table %s",
+                            this->table->s->table_name.str);
 
       // Set subarray using capi
       this->ctx.handle_error(tiledb_query_set_subarray(
           this->ctx.ptr().get(), this->query->ptr().get(), subarray.get()));
 
     } else {
-      sql_print_information("pushdown of ranges for query");
+      sql_print_information("pushdown of ranges for query on table %s",
+                            this->table->s->table_name.str);
 
       // Loop over dimensions and build rangers for that dimension
       for (uint64_t dim_idx = 0; dim_idx < this->ndim; dim_idx++) {
@@ -440,7 +442,8 @@ int tile::mytile::init_scan(
         // If the ranges for this dimension are not empty, we'll push it down
         // else non empty domain is used
         if (!ranges.empty() || !in_ranges.empty()) {
-          sql_print_information("Pushdown for %s",
+          sql_print_information("Pushdown for %s.%s",
+                                this->table->s->table_name.str,
                                 dims[dim_idx].name().c_str());
 
           std::shared_ptr<tile::range> range = nullptr;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -43,7 +43,6 @@
 #include <handler.h>
 #include <memory>
 #include <tiledb/tiledb>
-#include <queue>
 
 #include "handler.h"   /* handler */
 #include "my_base.h"   /* ha_rows */
@@ -352,8 +351,7 @@ public:
 
   /**
    * Is the primary key clustered
-   * @return false to workaround mariadb assuming sequential index scans are
-   * faster than pushdown
+   * @return true because tiledb data is storted based on dimensions and layout
    */
   bool primary_key_is_clustered() override { return TRUE; }
 
@@ -379,6 +377,15 @@ public:
    */
   int index_end() override;
 
+  /**
+   * Perform a scan over query results to find the specified key
+   * This performs a sequence scan to find a key. It is used for index scans or
+   * MRR
+   * @param key key to find
+   * @param key_len length of key indicating the key parts
+   * @param find_flag
+   * @return
+   */
   int index_read_scan(const uchar *key, uint key_len,
                       enum ha_rkey_function find_flag);
 
@@ -518,8 +525,16 @@ private:
   int reset_pushdowns_for_key(const uchar *key, uint key_len,
                               enum ha_rkey_function find_flag);
 
+  /**
+   * Build MRR ranges from current handle mrr details
+   * @return
+   */
   int build_mrr_ranges();
 
+  /**
+   * Check if a query is complete or not
+   * @return true if query is complete, false otherwise
+   */
   bool query_complete();
 };
 } // namespace tile

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -354,7 +354,7 @@ public:
    * @return false to workaround mariadb assuming sequential index scans are
    * faster than pushdown
    */
-  bool primary_key_is_clustered() override { return FALSE; }
+  bool primary_key_is_clustered() override { return TRUE; }
 
   /**
    * Pushdown an index condition
@@ -399,7 +399,25 @@ public:
   ha_rows records_in_range(uint inx, key_range *min_key,
                            key_range *max_key) override;
 
+  /**
+   * Multi Range Read interface
+   */
+  int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
+                            uint n_ranges, uint mode,
+                            HANDLER_BUFFER *buf) override;
+  int multi_range_read_next(range_id_t *range_info) override;
+  ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
+                                      void *seq_init_param, uint n_ranges,
+                                      uint *bufsz, uint *flags,
+                                      Cost_estimate *cost) override;
+  ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
+                                uint key_parts, uint *bufsz, uint *flags,
+                                Cost_estimate *cost) override;
+  int multi_range_read_explain_info(uint mrr_mode, char *str,
+                                    size_t size) override;
+
 private:
+  DsMrr_impl ds_mrr;
   // Table uri
   std::string uri;
 

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -140,7 +140,7 @@ public:
    * Read next Row
    * @return
    */
-  int rnd_row(TABLE *table);
+  int scan_rnd_row(TABLE *table);
 
   /**
    * Read next row
@@ -379,6 +379,9 @@ public:
    */
   int index_end() override;
 
+  int index_read_scan(const uchar *key, uint key_len,
+                      enum ha_rkey_function find_flag);
+
   /**
    * Read "first" row
    * @param buf
@@ -516,8 +519,6 @@ private:
                               enum ha_rkey_function find_flag);
 
   int build_mrr_ranges();
-
-  std::queue<KEY_MULTI_RANGE> mrr_key_ranges;
 
   bool query_complete();
 };

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -43,6 +43,7 @@
 #include <handler.h>
 #include <memory>
 #include <tiledb/tiledb>
+#include <queue>
 
 #include "handler.h"   /* handler */
 #include "my_base.h"   /* ha_rows */
@@ -513,5 +514,11 @@ private:
    */
   int reset_pushdowns_for_key(const uchar *key, uint key_len,
                               enum ha_rkey_function find_flag);
+
+  int build_mrr_ranges();
+
+  std::queue<KEY_MULTI_RANGE> mrr_key_ranges;
+
+  bool query_complete();
 };
 } // namespace tile

--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -87,56 +87,59 @@ tile::merge_ranges(std::vector<std::shared_ptr<tile::range>> &ranges,
   return nullptr;
 }
 
-void tile::setup_range(const std::shared_ptr<range> &range,
+void tile::setup_range(THD *thd, const std::shared_ptr<range> &range,
                        void *non_empty_domain, tiledb::Dimension dimension) {
   switch (dimension.type()) {
   case tiledb_datatype_t::TILEDB_FLOAT64:
-    return setup_range<double>(range, static_cast<double *>(non_empty_domain));
+    return setup_range<double>(thd, range,
+                               static_cast<double *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_FLOAT32:
-    return setup_range<float>(range, static_cast<float *>(non_empty_domain));
+    return setup_range<float>(thd, range,
+                              static_cast<float *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_INT8:
-    return setup_range<int8_t>(range, static_cast<int8_t *>(non_empty_domain));
+    return setup_range<int8_t>(thd, range,
+                               static_cast<int8_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_UINT8:
-    return setup_range<uint8_t>(range,
+    return setup_range<uint8_t>(thd, range,
                                 static_cast<uint8_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_INT16:
-    return setup_range<int16_t>(range,
+    return setup_range<int16_t>(thd, range,
                                 static_cast<int16_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_UINT16:
-    return setup_range<uint16_t>(range,
+    return setup_range<uint16_t>(thd, range,
                                  static_cast<uint16_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_INT32:
-    return setup_range<int32_t>(range,
+    return setup_range<int32_t>(thd, range,
                                 static_cast<int32_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_UINT32:
-    return setup_range<uint32_t>(range,
+    return setup_range<uint32_t>(thd, range,
                                  static_cast<uint32_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_INT64:
-    return setup_range<int64_t>(range,
+    return setup_range<int64_t>(thd, range,
                                 static_cast<int64_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_UINT64:
-    return setup_range<uint64_t>(range,
+    return setup_range<uint64_t>(thd, range,
                                  static_cast<uint64_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_DATETIME_DAY:
-    return setup_range<int64_t>(range,
+    return setup_range<int64_t>(thd, range,
                                 static_cast<int64_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_DATETIME_YEAR:
-    return setup_range<int64_t>(range,
+    return setup_range<int64_t>(thd, range,
                                 static_cast<int64_t *>(non_empty_domain));
 
   case tiledb_datatype_t::TILEDB_DATETIME_NS:
-    return setup_range<int64_t>(range,
+    return setup_range<int64_t>(thd, range,
                                 static_cast<int64_t *>(non_empty_domain));
 
   default: {

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -60,7 +60,7 @@ typedef struct range_struct {
 int set_range_from_item_consts(Item_basic_constant *lower_const,
                                Item_basic_constant *upper_const,
                                Item_result cmp_type,
-                               std::shared_ptr<range> &range);
+                               std::shared_ptr<tile::range> &range);
 /**
  * Take a range, and will set the lower/upper bound as appropriate if it is
  * missing and takes into account the mariadb operations.
@@ -85,11 +85,11 @@ int set_range_from_item_consts(Item_basic_constant *lower_const,
  * @param non_empty_domain
  * @param dimension
  */
-void setup_range(THD *thd, const std::shared_ptr<range> &range,
+void setup_range(THD *thd, const std::shared_ptr<tile::range> &range,
                  void *non_empty_domain, tiledb::Dimension dimension);
 
 template <typename T>
-void setup_range(THD *thd, const std::shared_ptr<range> &range,
+void setup_range(THD *thd, const std::shared_ptr<tile::range> &range,
                  T *non_empty_domain) {
   T final_lower_value;
   T final_upper_value;
@@ -199,46 +199,157 @@ void setup_range(THD *thd, const std::shared_ptr<range> &range,
       std::to_string(*static_cast<T *>(range->upper_value.get())).c_str());
 }
 
-std::shared_ptr<range> merge_ranges(std::vector<std::shared_ptr<range>> &ranges,
-                                    tiledb_datatype_t datatype);
+std::shared_ptr<tile::range>
+merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges,
+             tiledb_datatype_t datatype);
 
 template <typename T>
-std::shared_ptr<range>
-merge_ranges(std::vector<std::shared_ptr<range>> &ranges) {
-  std::shared_ptr<range> merged_range;
+std::shared_ptr<tile::range>
+merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
+  std::shared_ptr<tile::range> merged_range =
+      std::make_shared<tile::range>(tile::range{
+          std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+          std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+          Item_func::EQ_FUNC, tiledb_datatype_t::TILEDB_ANY});
 
   if (ranges.empty())
     return nullptr;
 
   // Set the first element as the default for the merged range, this gives us
   // some initial values to compare against
-  merged_range = std::move(ranges[0]);
-  // Remove first element since its now set as initial range
-  ranges.erase(ranges.begin());
+  merged_range->operation_type = ranges[0]->operation_type;
+  merged_range->datatype = ranges[0]->datatype;
+
+  if (ranges[0]->lower_value != nullptr) {
+    merged_range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+        std::malloc(sizeof(T)), &std::free);
+    memcpy(merged_range->lower_value.get(), ranges[0]->lower_value.get(),
+           sizeof(T));
+  }
+
+  if (ranges[0]->upper_value != nullptr) {
+    merged_range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+        std::malloc(sizeof(T)), &std::free);
+    memcpy(merged_range->upper_value.get(), ranges[0]->upper_value.get(),
+           sizeof(T));
+  }
 
   // loop through ranges and set upper/lower maxima/minima
   for (auto &range : ranges) {
     if (range->lower_value != nullptr) {
       if (merged_range->lower_value == nullptr) {
-        merged_range->lower_value = std::move(range->lower_value);
+        merged_range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+            std::malloc(sizeof(T)), &std::free);
+        memcpy(merged_range->lower_value.get(), range->lower_value.get(),
+               sizeof(T));
+        //        merged_range->lower_value = std::move(range->lower_value);
         // See if the current range has a higher low value than the "merged"
         // range, if so set the new low value, since the current range has a
         // more restrictive condition
       } else if (*(static_cast<T *>(merged_range->lower_value.get())) <
                  *(static_cast<T *>(range->lower_value.get()))) {
-        merged_range->lower_value = std::move(range->lower_value);
+        memcpy(merged_range->lower_value.get(), range->lower_value.get(),
+               sizeof(T));
+        //        merged_range->lower_value = std::move(range->lower_value);
       }
     }
 
     if (range->upper_value != nullptr) {
       if (merged_range->upper_value == nullptr) {
-        merged_range->upper_value = std::move(range->upper_value);
+        merged_range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+            std::malloc(sizeof(T)), &std::free);
+        memcpy(merged_range->upper_value.get(), range->upper_value.get(),
+               sizeof(T));
+        //        merged_range->upper_value = std::move(range->upper_value);
         // See if the current range has a lower upper value than the "merged"
         // range, if so set the new upper value since the current range has a
         // more restrictive condition
       } else if (*(static_cast<T *>(merged_range->upper_value.get())) >
                  *(static_cast<T *>(range->upper_value.get()))) {
-        merged_range->upper_value = std::move(range->upper_value);
+        memcpy(merged_range->upper_value.get(), range->upper_value.get(),
+               sizeof(T));
+        //        merged_range->upper_value = std::move(range->upper_value);
+      }
+    }
+  }
+
+  // If we have set the upper and lower let's make it a between.
+  if (merged_range != nullptr && merged_range->upper_value != nullptr &&
+      merged_range->lower_value != nullptr) {
+    merged_range->operation_type = Item_func::BETWEEN;
+  }
+
+  return merged_range;
+}
+
+std::shared_ptr<tile::range>
+merge_ranges_to_super(const std::vector<std::shared_ptr<tile::range>> &ranges,
+                      tiledb_datatype_t datatype);
+
+template <typename T>
+std::shared_ptr<tile::range>
+merge_ranges_to_super(const std::vector<std::shared_ptr<tile::range>> &ranges) {
+  std::shared_ptr<tile::range> merged_range =
+      std::make_shared<tile::range>(tile::range{
+          std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+          std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+          Item_func::EQ_FUNC, tiledb_datatype_t::TILEDB_ANY});
+
+  if (ranges.empty())
+    return nullptr;
+
+  // Set the first element as the default for the merged range, this gives us
+  // some initial values to compare against
+  merged_range->operation_type = ranges[0]->operation_type;
+  merged_range->datatype = ranges[0]->datatype;
+
+  if (ranges[0]->lower_value != nullptr) {
+    merged_range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+        std::malloc(sizeof(T)), &std::free);
+    memcpy(merged_range->lower_value.get(), ranges[0]->lower_value.get(),
+           sizeof(T));
+  }
+
+  if (ranges[0]->upper_value != nullptr) {
+    merged_range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+        std::malloc(sizeof(T)), &std::free);
+    memcpy(merged_range->upper_value.get(), ranges[0]->upper_value.get(),
+           sizeof(T));
+  }
+
+  // loop through ranges and set upper/lower maxima/minima
+  for (auto &range : ranges) {
+    if (range->lower_value != nullptr) {
+      if (merged_range->lower_value == nullptr) {
+        merged_range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+            std::malloc(sizeof(T)), &std::free);
+        memcpy(merged_range->lower_value.get(), range->lower_value.get(),
+               sizeof(T));
+        // See if the current range has a lower low value than the "merged"
+        // range, if so set the new low value, since the current range includes
+        // additional data
+      } else if (*(static_cast<T *>(merged_range->lower_value.get())) >
+                 *(static_cast<T *>(range->lower_value.get()))) {
+        //        merged_range->lower_value = std::move(range->lower_value);
+        memcpy(merged_range->lower_value.get(), range->lower_value.get(),
+               sizeof(T));
+      }
+    }
+
+    if (range->upper_value != nullptr) {
+      if (merged_range->upper_value == nullptr) {
+        merged_range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+            std::malloc(sizeof(T)), &std::free);
+        memcpy(merged_range->upper_value.get(), range->upper_value.get(),
+               sizeof(T));
+        // See if the current range has a higher upper value than the "merged"
+        // range, if so set the new upper value since the current range includes
+        // additional data
+      } else if (*(static_cast<T *>(merged_range->upper_value.get())) <
+                 *(static_cast<T *>(range->upper_value.get()))) {
+        //        merged_range->upper_value = std::move(range->upper_value);
+        memcpy(merged_range->upper_value.get(), range->upper_value.get(),
+               sizeof(T));
       }
     }
   }
@@ -260,17 +371,17 @@ merge_ranges(std::vector<std::shared_ptr<range>> &ranges) {
  * @param main_range
  * @return
  */
-std::vector<std::shared_ptr<range>> get_unique_non_contained_in_ranges(
-    const std::vector<std::shared_ptr<range>> &in_ranges,
-    const std::shared_ptr<range> &main_range);
+std::vector<std::shared_ptr<tile::range>> get_unique_non_contained_in_ranges(
+    const std::vector<std::shared_ptr<tile::range>> &in_ranges,
+    const std::shared_ptr<tile::range> &main_range);
 
 template <typename T>
-std::vector<std::shared_ptr<range>> get_unique_non_contained_in_ranges(
-    const std::vector<std::shared_ptr<range>> &in_ranges,
-    const std::shared_ptr<range> &main_range) {
+std::vector<std::shared_ptr<tile::range>> get_unique_non_contained_in_ranges(
+    const std::vector<std::shared_ptr<tile::range>> &in_ranges,
+    const std::shared_ptr<tile::range> &main_range) {
 
   // Return unique non contained ranges
-  std::vector<std::shared_ptr<range>> ret;
+  std::vector<std::shared_ptr<tile::range>> ret;
 
   std::unordered_set<T> unique_values_set;
   std::vector<T> unique_values_vec;
@@ -315,10 +426,11 @@ std::vector<std::shared_ptr<range>> get_unique_non_contained_in_ranges(
   // from unique values build final ranges
   for (T val : unique_values_vec) {
     // Build range pointer
-    std::shared_ptr<range> range = std::make_shared<tile::range>(tile::range{
-        std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
-        std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
-        Item_func::EQ_FUNC, datatype});
+    std::shared_ptr<tile::range> range =
+        std::make_shared<tile::range>(tile::range{
+            std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+            std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),
+            Item_func::EQ_FUNC, datatype});
 
     // Allocate memory for lower value
     range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
@@ -470,5 +582,157 @@ build_ranges_from_key(const uchar *key, uint length,
   ranges.push_back(std::move(last_dimension_range));
 
   return ranges;
+}
+
+void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
+                                           key_range key,
+                                           uint64_t dimension_index,
+                                           tiledb_datatype_t datatype);
+
+template <typename T>
+void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
+                                           key_range key,
+                                           uint64_t dimension_index) {
+  const T *typed_key = reinterpret_cast<const T *>(key.key);
+
+  T key_value = typed_key[dimension_index];
+
+  auto operation_type = find_flag_to_func(key.flag);
+  switch (operation_type) {
+  // If we have greater than, lets make it greater than or equal
+  // TileDB ranges are inclusive
+  case Item_func::GT_FUNC: {
+    if (std::is_floating_point<T>()) {
+      key_value = std::nextafter(key_value, static_cast<T>(1.0f));
+    } else {
+      key_value += 1;
+    }
+
+    // If the lower is null, set it
+    if (range->lower_value == nullptr) {
+      range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+    // If the current lower_value is greater than the key set the new lower
+    // value
+    else if (*static_cast<T *>(range->lower_value.get()) > key_value) {
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+    break;
+  }
+  case Item_func::GE_FUNC: {
+    // If the lower is null, set it
+    if (range->lower_value == nullptr) {
+      range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+    // If the current lower_value is greater than the key set the new lower
+    // value
+    else if (*static_cast<T *>(range->lower_value.get()) > key_value) {
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+    break;
+  }
+  case Item_func::LT_FUNC: {
+    // If we have less than, lets make it less than or equal
+    // TileDB ranges are inclusive
+    range->operation_type = Item_func::LE_FUNC;
+    if (std::is_floating_point<T>()) {
+      key_value = std::nextafter(key_value, static_cast<T>(-1.0f));
+    } else {
+      key_value -= 1;
+    }
+
+    // If the upper is null, set it
+    if (range->upper_value == nullptr) {
+      range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+    // If the current upper_value is less than the key set the new upper value
+    else if (*static_cast<T *>(range->upper_value.get()) < key_value) {
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+
+    break;
+  }
+  case Item_func::LE_FUNC: {
+    // If the upper is null, set it
+    if (range->upper_value == nullptr) {
+      range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+    // If the current upper_value is less than the key set the new upper value
+    else if (*static_cast<T *>(range->upper_value.get()) < key_value) {
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+
+    break;
+  }
+  case Item_func::EQ_FUNC: {
+
+    // If the lower is null, set it
+    if (range->lower_value == nullptr) {
+      range->lower_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+    // If the current lower_value is greater than the key set the new lower
+    // value
+    else if (*static_cast<T *>(range->lower_value.get()) > key_value) {
+      memcpy(range->lower_value.get(), &key_value, sizeof(T));
+    }
+
+    // If the upper is null, set it
+    if (range->upper_value == nullptr) {
+      range->upper_value = std::unique_ptr<void, decltype(&std::free)>(
+          std::malloc(sizeof(T)), &std::free);
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+    // If the current upper_value is less than the key set the new upper value
+    else if (*static_cast<T *>(range->upper_value.get()) < key_value) {
+      memcpy(range->upper_value.get(), &key_value, sizeof(T));
+    }
+
+    break;
+  }
+  default:
+    my_printf_error(ER_UNKNOWN_ERROR,
+                    "Unsupported Item_func::functype in "
+                    "update_range_from_key_for_super_range",
+                    ME_ERROR_LOG | ME_FATAL);
+    break;
+  }
+}
+
+/**
+ * Compares two buffers of a type datatype numerically
+ * @param lhs
+ * @param rhs
+ * @param size
+ * @param datatype
+ * @return -1 if lhs is less than rhs, 0 if equal 1 if lhs is greater than rhs
+ */
+int8_t compare_typed_buffers(const void *lhs, const void *rhs, uint64_t size,
+                             tiledb_datatype_t datatype);
+
+template <typename T>
+int8_t compare_typed_buffers(const void *lhs, const void *rhs, uint64_t size) {
+  const T *lhs_typed = reinterpret_cast<const T *>(lhs);
+  const T *rhs_typed = reinterpret_cast<const T *>(rhs);
+
+  for (uint64_t i = 0; i < size / sizeof(T); i++) {
+    if (lhs_typed[i] > rhs_typed[i]) {
+      return 1;
+    } else if (lhs_typed[i] < rhs_typed[i]) {
+      return -1;
+    }
+  }
+
+  // If we are here then all lhs parts are equal
+  return 0;
 }
 } // namespace tile

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -43,6 +43,7 @@
 #include <log.h>
 #include <tiledb/tiledb>
 #include <unordered_set>
+#include "utils.h"
 
 namespace tile {
 /**
@@ -79,15 +80,17 @@ int set_range_from_item_consts(Item_basic_constant *lower_const,
  * {lower_value = 11, upper_value=non_empty_domain[1],
  * operation_type=Item_func::GT_FUNC, datatype=TILEDB_INT32}
  *
+ * @param thd
  * @param range
  * @param non_empty_domain
  * @param dimension
  */
-void setup_range(const std::shared_ptr<range> &range, void *non_empty_domain,
-                 tiledb::Dimension dimension);
+void setup_range(THD *thd, const std::shared_ptr<range> &range,
+                 void *non_empty_domain, tiledb::Dimension dimension);
 
 template <typename T>
-void setup_range(const std::shared_ptr<range> &range, T *non_empty_domain) {
+void setup_range(THD *thd, const std::shared_ptr<range> &range,
+                 T *non_empty_domain) {
   T final_lower_value;
   T final_upper_value;
   switch (range->operation_type) {
@@ -190,8 +193,8 @@ void setup_range(const std::shared_ptr<range> &range, T *non_empty_domain) {
   }        // endswitch functype
 
   // log conditions for debug
-  sql_print_information(
-      "pushed conditions: [%s, %s]",
+  log_debug(
+      thd, "pushed conditions: [%s, %s]",
       std::to_string(*static_cast<T *>(range->lower_value.get())).c_str(),
       std::to_string(*static_cast<T *>(range->upper_value.get())).c_str());
 }

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -207,11 +207,11 @@ merge_ranges(std::vector<std::shared_ptr<range>> &ranges) {
   if (ranges.empty())
     return nullptr;
 
-  // Set the last element as the default for the merged range, this gives us
+  // Set the first element as the default for the merged range, this gives us
   // some initial values to compare against
-  merged_range = std::move(ranges[ranges.size() - 1]);
-  // Remove last element since its now set as initial range
-  ranges.pop_back();
+  merged_range = std::move(ranges[0]);
+  // Remove first element since its now set as initial range
+  ranges.erase(ranges.begin());
 
   // loop through ranges and set upper/lower maxima/minima
   for (auto &range : ranges) {
@@ -269,7 +269,8 @@ std::vector<std::shared_ptr<range>> get_unique_non_contained_in_ranges(
   // Return unique non contained ranges
   std::vector<std::shared_ptr<range>> ret;
 
-  std::unordered_set<T> unique_values;
+  std::unordered_set<T> unique_values_set;
+  std::vector<T> unique_values_vec;
 
   // get datatype
   tiledb_datatype_t datatype;
@@ -302,11 +303,14 @@ std::vector<std::shared_ptr<range>> get_unique_non_contained_in_ranges(
     }
 
     // Add value to set
-    unique_values.insert(range_lower_value);
+    if (unique_values_set.count(range_lower_value) == 0) {
+      unique_values_set.insert(range_lower_value);
+      unique_values_vec.push_back(range_lower_value);
+    }
   }
 
   // from unique values build final ranges
-  for (T val : unique_values) {
+  for (T val : unique_values_vec) {
     // Build range pointer
     std::shared_ptr<range> range = std::make_shared<tile::range>(tile::range{
         std::unique_ptr<void, decltype(&std::free)>(nullptr, &std::free),

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -199,10 +199,24 @@ void setup_range(THD *thd, const std::shared_ptr<tile::range> &range,
       std::to_string(*static_cast<T *>(range->upper_value.get())).c_str());
 }
 
+/**
+ * Merge ranges to remove overlap, and produce the most constrained ranges.
+ * This is used mostly for condition pushdown to narrow ranges which are dim0 >
+ * X and dim0 < Y and dim0 < Y-1 to have a range of [X, Y-1]
+ * @param ranges ranges to merge
+ * @param datatype
+ * @return
+ */
 std::shared_ptr<tile::range>
 merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges,
              tiledb_datatype_t datatype);
 
+/**
+ * See non-templated function for description
+ * @tparam T
+ * @param ranges
+ * @return
+ */
 template <typename T>
 std::shared_ptr<tile::range>
 merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
@@ -242,7 +256,6 @@ merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
             std::malloc(sizeof(T)), &std::free);
         memcpy(merged_range->lower_value.get(), range->lower_value.get(),
                sizeof(T));
-        //        merged_range->lower_value = std::move(range->lower_value);
         // See if the current range has a higher low value than the "merged"
         // range, if so set the new low value, since the current range has a
         // more restrictive condition
@@ -250,7 +263,6 @@ merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
                  *(static_cast<T *>(range->lower_value.get()))) {
         memcpy(merged_range->lower_value.get(), range->lower_value.get(),
                sizeof(T));
-        //        merged_range->lower_value = std::move(range->lower_value);
       }
     }
 
@@ -260,7 +272,6 @@ merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
             std::malloc(sizeof(T)), &std::free);
         memcpy(merged_range->upper_value.get(), range->upper_value.get(),
                sizeof(T));
-        //        merged_range->upper_value = std::move(range->upper_value);
         // See if the current range has a lower upper value than the "merged"
         // range, if so set the new upper value since the current range has a
         // more restrictive condition
@@ -268,7 +279,6 @@ merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
                  *(static_cast<T *>(range->upper_value.get()))) {
         memcpy(merged_range->upper_value.get(), range->upper_value.get(),
                sizeof(T));
-        //        merged_range->upper_value = std::move(range->upper_value);
       }
     }
   }
@@ -282,10 +292,23 @@ merge_ranges(const std::vector<std::shared_ptr<tile::range>> &ranges) {
   return merged_range;
 }
 
+/**
+ * Merge ranges into larger super ranges, this is used mostly for key scans and
+ * MRR
+ * @param ranges ranges to merge
+ * @param datatype
+ * @return single range which is the merged super range
+ */
 std::shared_ptr<tile::range>
 merge_ranges_to_super(const std::vector<std::shared_ptr<tile::range>> &ranges,
                       tiledb_datatype_t datatype);
 
+/**
+ * See non-templated function for description
+ * @tparam T
+ * @param ranges
+ * @return
+ */
 template <typename T>
 std::shared_ptr<tile::range>
 merge_ranges_to_super(const std::vector<std::shared_ptr<tile::range>> &ranges) {
@@ -375,6 +398,13 @@ std::vector<std::shared_ptr<tile::range>> get_unique_non_contained_in_ranges(
     const std::vector<std::shared_ptr<tile::range>> &in_ranges,
     const std::shared_ptr<tile::range> &main_range);
 
+/**
+ * See non-templated function for description
+ * @tparam T
+ * @param in_ranges
+ * @param main_range
+ * @return
+ */
 template <typename T>
 std::vector<std::shared_ptr<tile::range>> get_unique_non_contained_in_ranges(
     const std::vector<std::shared_ptr<tile::range>> &in_ranges,
@@ -583,12 +613,25 @@ build_ranges_from_key(const uchar *key, uint length,
 
   return ranges;
 }
-
+/**
+ * Update a range struct with a new key value. This will expand the super range
+ * if needed
+ * @param range range to modify
+ * @param key key to add/include in super range
+ * @param dimension_index dimension index of range
+ * @param datatype
+ */
 void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
                                            key_range key,
                                            uint64_t dimension_index,
                                            tiledb_datatype_t datatype);
-
+/**
+ * See non-templated version for description
+ * @tparam T
+ * @param range
+ * @param key
+ * @param dimension_index
+ */
 template <typename T>
 void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
                                            key_range key,
@@ -719,6 +762,14 @@ void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
 int8_t compare_typed_buffers(const void *lhs, const void *rhs, uint64_t size,
                              tiledb_datatype_t datatype);
 
+/**
+ * See non-templated function for description
+ * @tparam T
+ * @param lhs
+ * @param rhs
+ * @param size
+ * @return
+ */
 template <typename T>
 int8_t compare_typed_buffers(const void *lhs, const void *rhs, uint64_t size) {
   const T *lhs_typed = reinterpret_cast<const T *>(lhs);

--- a/mytile/mytile-sysvars.cc
+++ b/mytile/mytile-sysvars.cc
@@ -102,6 +102,14 @@ static MYSQL_THDVAR_BOOL(compute_table_records,
                          "compute size of table (record count) on opening",
                          NULL, NULL, false);
 
+const char *log_level_names[] = {"error", "warning", "info", "debug", NullS};
+
+TYPELIB log_level_typelib = {array_elements(log_level_names) - 1,
+                             "log_level_typelib", log_level_names, NULL};
+
+static MYSQL_THDVAR_ENUM(log_level, PLUGIN_VAR_OPCMDARG, "log level for mytile",
+                         NULL, NULL, 1, &log_level_typelib);
+
 // system variables
 struct st_mysql_sys_var *mytile_system_variables[] = {
     MYSQL_SYSVAR(read_buffer_size),
@@ -113,6 +121,7 @@ struct st_mysql_sys_var *mytile_system_variables[] = {
     MYSQL_SYSVAR(dimensions_are_primary_keys),
     MYSQL_SYSVAR(enable_pushdown),
     MYSQL_SYSVAR(compute_table_records),
+    MYSQL_SYSVAR(log_level),
     NULL};
 
 ulonglong read_buffer_size(THD *thd) { return THDVAR(thd, read_buffer_size); }
@@ -141,5 +150,7 @@ my_bool enable_pushdown(THD *thd) { return THDVAR(thd, enable_pushdown); }
 my_bool compute_table_records(THD *thd) {
   return THDVAR(thd, compute_table_records);
 }
+
+LOG_LEVEL log_level(THD *thd) { return LOG_LEVEL(THDVAR(thd, log_level)); }
 } // namespace sysvars
 } // namespace tile

--- a/mytile/mytile-sysvars.h
+++ b/mytile/mytile-sysvars.h
@@ -42,6 +42,8 @@
 
 namespace tile {
 namespace sysvars {
+enum class LOG_LEVEL { ERROR = 0, WARNING = 1, INFORMATION = 2, DEBUG = 3 };
+
 // list of system parameters
 extern struct st_mysql_sys_var *mytile_system_variables[];
 
@@ -62,6 +64,8 @@ my_bool dimensions_are_primary_keys(THD *thd);
 my_bool enable_pushdown(THD *thd);
 
 my_bool compute_table_records(THD *thd);
+
+LOG_LEVEL log_level(THD *thd);
 } // namespace sysvars
 } // namespace tile
 

--- a/mytile/utils.cc
+++ b/mytile/utils.cc
@@ -31,6 +31,7 @@
  */
 
 #include "utils.h"
+#include "mytile-sysvars.h"
 #include <string>
 #include <vector>
 #include <sstream>
@@ -73,4 +74,48 @@ bool tile::compare_configs(tiledb::Config &rhs, tiledb::Config &lhs) {
   }
 
   return true;
+}
+
+void tile::log_error(THD *thd, const char *msg, ...) {
+
+  if (tile::sysvars::log_level(thd) > tile::sysvars::LOG_LEVEL::ERROR)
+    return;
+
+  va_list args;
+  va_start(args, msg);
+  error_log_print(ERROR_LEVEL, msg, args);
+  va_end(args);
+}
+
+void tile::log_warning(THD *thd, const char *msg, ...) {
+
+  if (tile::sysvars::log_level(thd) > tile::sysvars::LOG_LEVEL::WARNING)
+    return;
+
+  va_list args;
+  va_start(args, msg);
+  error_log_print(WARNING_LEVEL, msg, args);
+  va_end(args);
+}
+
+void tile::log_info(THD *thd, const char *msg, ...) {
+
+  if (tile::sysvars::log_level(thd) > tile::sysvars::LOG_LEVEL::INFORMATION)
+    return;
+
+  va_list args;
+  va_start(args, msg);
+  error_log_print(INFORMATION_LEVEL, msg, args);
+  va_end(args);
+}
+
+void tile::log_debug(THD *thd, const char *msg, ...) {
+
+  if (tile::sysvars::log_level(thd) != tile::sysvars::LOG_LEVEL::DEBUG)
+    return;
+
+  va_list args;
+  va_start(args, msg);
+  error_log_print(INFORMATION_LEVEL, msg, args);
+  va_end(args);
 }

--- a/mytile/utils.h
+++ b/mytile/utils.h
@@ -104,4 +104,36 @@ tiledb::Context build_context(tiledb::Config &cfg);
  * @return true is identical, false otherwise
  */
 bool compare_configs(tiledb::Config &rhs, tiledb::Config &lhs);
+
+/**
+ * Log errors only if log level is set to error or higher
+ * @param thd thd to get log level from
+ * @param msg message to log
+ * @param ... formatting parameters for message
+ */
+void log_error(THD *thd, const char *msg, ...);
+
+/**
+ * Log errors only if log level is set to warning or higher
+ * @param thd thd to get log level from
+ * @param msg message to log
+ * @param ... formatting parameters for message
+ */
+void log_warning(THD *thd, const char *msg, ...);
+
+/**
+ * Log errors only if log level is set to info or higher
+ * @param thd thd to get log level from
+ * @param msg message to log
+ * @param ... formatting parameters for message
+ */
+void log_info(THD *thd, const char *msg, ...);
+
+/**
+ * Log errors only if log level is set to debug or higher
+ * @param thd thd to get log level from
+ * @param msg message to log
+ * @param ... formatting parameters for message
+ */
+void log_debug(THD *thd, const char *msg, ...);
 } // namespace tile


### PR DESCRIPTION
This is a large patchset which adds support for MRR scans, useful for joins. It greatly improves join performance by allowing Batched Key Access (BKA) for joins.

Index scanning was also improved and a new index scan function implemented which will perform a scan on the coordinate buffers to find the key asked for during BKA or full index scan operations.

In addition a new parameter `log_level` is added to allow controlling mytile log messages.