### PR TITLE
Update mariadb versions to 10.4.11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,9 +51,9 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
-ENV MARIADB_VERSION="mariadb-10.4.8"
+ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.2.2"
+ARG MYTILE_VERSION="0.3.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -57,7 +57,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y \
   libcurl4-openssl-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ENV MARIADB_VERSION="mariadb-10.4.8"
+ENV MARIADB_VERSION="mariadb-10.4.11"
 
 ADD . /tmp/mytile
 

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -51,9 +51,9 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
-ENV MARIADB_VERSION="mariadb-10.4.8"
+ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.2.2"
+ARG MYTILE_VERSION="0.3.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -55,16 +55,16 @@ steps:
 
 - bash: |
     set -e pipefail
-    BUILDDIR=$BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.8/builddir/mysql-test/var/log/mysqld.1.err
+    BUILDDIR=$BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.11/builddir/mysql-test/var/log/mysqld.1.err
     # Display log files if the build failed
     echo "Dumping log files for failed build"
     echo "----------------------------------"
     echo "$BUILD_REPOSITORY_LOCALPATH"
     ls $BUILD_REPOSITORY_LOCALPATH/
-    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.8/builddir/
-    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.8/builddir/mysql-test/
-    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.8/builddir/mysql-test/var/
-    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.8/builddir/mysql-test/var/log
+    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.11/builddir/
+    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.11/builddir/mysql-test/
+    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.11/builddir/mysql-test/var/
+    ls $BUILD_REPOSITORY_LOCALPATH/mariadb-10.4.11/builddir/mysql-test/var/log
     echo "$BUILDDIR"
     echo "======"
     cat $BUILDDIR

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -3,17 +3,17 @@
 set -v -e -x
 
 original_dir=$PWD
-export MARIADB_VERSION="mariadb-10.4.8"
+export MARIADB_VERSION="mariadb-10.4.11"
 mkdir tmp
 shopt -s extglob
 mv !(tmp) tmp # Move everything but tmp
 # Download mariadb, this has a habit of failing so let's do it first
-#wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz
-git clone https://github.com/Shelnutt2/server.git -b MDEV-20767-10.4 ${MARIADB_VERSION}
+wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz
+tar xf ${MARIADB_VERSION}.tar.gz
 
-# Install tiledb using 1.6 release
+# Install tiledb using 1.7.2 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.0 && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
 && mkdir -p build && cd build
 
 # Configure and build TileDB
@@ -22,7 +22,6 @@ cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD
 && sudo make -C tiledb install \
 && cd $original_dir
 
-#tar xf ${MARIADB_VERSION}.tar.gz \
 mv tmp ${MARIADB_VERSION}/storage/mytile \
 && cd ${MARIADB_VERSION} \
 && mkdir builddir \


### PR DESCRIPTION
Update mariadb versions to 10.4.11 for CI and docker. Also update TileDB to 1.7.2 for docker and CI.