### PR TITLE
Add support for open_at via table option

### DIFF
--- a/mysql-test/mytile/r/open_at.result
+++ b/mysql-test/mytile/r/open_at.result
@@ -1,0 +1,47 @@
+#
+# The purpose of this test is to test array open_at (time travelling) functionality
+#
+# Setup existing array first, open once with default time (now()) and one with unix epoch
+CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+CREATE TABLE quickstart_dense_zero ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' open_at=0;;
+show create table quickstart_dense;
+Table	Create Table
+quickstart_dense	CREATE TABLE `quickstart_dense` (
+  `rows` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
+  `cols` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
+  `a` int(11) DEFAULT NULL,
+  PRIMARY KEY (`rows`,`cols`)
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR
+show create table quickstart_dense_zero;
+Table	Create Table
+quickstart_dense_zero	CREATE TABLE `quickstart_dense_zero` (
+  `rows` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
+  `cols` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
+  `a` int(11) DEFAULT NULL,
+  PRIMARY KEY (`rows`,`cols`)
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `open_at`=0
+select * FROM quickstart_dense;
+rows	cols	a
+1	1	1
+1	2	2
+1	3	3
+1	4	4
+2	1	5
+2	2	6
+2	3	7
+2	4	8
+3	1	9
+3	2	10
+3	3	11
+3	4	12
+4	1	13
+4	2	14
+4	3	15
+4	4	16
+# Validate epoch of 0 returns no data since its before test array was created
+select * FROM quickstart_dense_zero;
+rows	cols	a
+SET mytile_delete_arrays=0;
+DROP TABLE quickstart_dense;
+DROP TABLE quickstart_dense_zero;
+SET mytile_delete_arrays=1;

--- a/mysql-test/mytile/t/open_at.test
+++ b/mysql-test/mytile/t/open_at.test
@@ -1,0 +1,23 @@
+--echo #
+--echo # The purpose of this test is to test array open_at (time travelling) functionality
+--echo #
+
+--echo # Setup existing array first, open once with default time (now()) and one with unix epoch
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE quickstart_dense_zero ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' open_at=0;
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+show create table quickstart_dense;
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+show create table quickstart_dense_zero;
+
+select * FROM quickstart_dense;
+--echo # Validate epoch of 0 returns no data since its before test array was created
+select * FROM quickstart_dense_zero;
+
+SET mytile_delete_arrays=0;
+DROP TABLE quickstart_dense;
+DROP TABLE quickstart_dense_zero;
+SET mytile_delete_arrays=1;

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -148,6 +148,20 @@ int tile::discover_array(handlerton *hton, THD *thd, TABLE_SHARE *ts,
           std::string("Unknown or Unsupported cell order %s") + layout);
     }
 
+    // Check for open_at
+
+    ulonglong open_at = UINT64_MAX;
+    if (info != nullptr && info->option_struct != nullptr) {
+      open_at = info->option_struct->open_at;
+    }
+    if (open_at == UINT64_MAX && ts != nullptr &&
+        ts->option_struct != nullptr) {
+      open_at = ts->option_struct->open_at;
+    }
+    if (open_at != UINT64_MAX) {
+      table_options << " open_at=" << open_at;
+    }
+
     for (const auto &dim : schema->domain().dimensions()) {
       std::string domain_str = dim.domain_to_str();
       domain_str = domain_str.substr(1, domain_str.size() - 2);

--- a/mytile/mytile.h
+++ b/mytile/mytile.h
@@ -18,6 +18,7 @@ struct ha_table_option_struct {
   uint array_type;
   ulonglong cell_order;
   ulonglong tile_order;
+  ulonglong open_at;
 };
 
 /** Field options */


### PR DESCRIPTION
A new table option `open_at` is provided to allow users to register a table to be opened for reads at a given time.

This will be rebased after #53  is merged.