### PR TITLE
Empty arrays should return empty dataset not error

### DIFF
--- a/mysql-test/mytile/r/empty_records.result
+++ b/mysql-test/mytile/r/empty_records.result
@@ -1,0 +1,11 @@
+#
+# The purpose of this test is to validate empty arrays return 0 records instead of errors
+#
+# INTEGER
+CREATE TABLE t1 (
+dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 integer
+) ENGINE=mytile;
+select * FROM t1;
+dim1	attr1
+DROP TABLE t1;

--- a/mysql-test/mytile/t/empty_records.test
+++ b/mysql-test/mytile/t/empty_records.test
@@ -1,0 +1,11 @@
+--echo #
+--echo # The purpose of this test is to validate empty arrays return 0 records instead of errors
+--echo #
+
+--echo # INTEGER
+CREATE TABLE t1 (
+  dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 integer
+) ENGINE=mytile;
+select * FROM t1;
+DROP TABLE t1;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -536,5 +536,9 @@ private:
    * @return true if query is complete, false otherwise
    */
   bool query_complete();
+
+  // Indicator for when non_empty_domain is empty and reads will return empty
+  // dataset
+  int empty_read = 0;
 };
 } // namespace tile


### PR DESCRIPTION
This changes the empty check to happen inside the scan_rnd_row or index_read_scan functions where MariaDB is expecting the HA_ERR_END_OF_FILE error instead of in init_scan.