### PR TITLE
 Add support for encrypted arrays

### DIFF
--- a/mysql-test/mytile/r/data_types.result
+++ b/mysql-test/mytile/r/data_types.result
@@ -27,7 +27,7 @@ column1 decimal(10,3) dimension=1 lower_bound="0" upper_bound="100" tile_extent=
 INSERT INTO t1 VALUES (1.1);
 select * FROM t1;
 column1
-1.1
+1.100
 DROP TABLE t1;
 # FLOAT
 CREATE TABLE t1 (
@@ -148,7 +148,7 @@ datetime1 DATETIME dimension=1 tile_extent="10"
 INSERT INTO t1 VALUES ("2017-08-13 00:00:00");
 select * FROM t1;
 datetime1
-2017-08-13 00:00:00.000000
+2017-08-13 00:00:00
 DROP TABLE t1;
 # DATETIME(6)
 CREATE TABLE t1 (
@@ -166,7 +166,7 @@ timestamp1 TIMESTAMP dimension=1 tile_extent="10"
 INSERT INTO t1 VALUES ("2017-08-13 00:00:00");
 select * FROM t1;
 timestamp1
-2017-08-13 00:00:00.000000
+2017-08-13 00:00:00
 DROP TABLE t1;
 # TIMESTAMP(6)
 CREATE TABLE t1 (

--- a/mysql-test/mytile/r/encryption.result
+++ b/mysql-test/mytile/r/encryption.result
@@ -1,0 +1,13 @@
+#
+# The purpose of this test is to test encryption
+#
+# INTEGER
+CREATE TABLE t1 (
+dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 integer
+) ENGINE=mytile encryption_key="testtesttesttesttesttesttesttest";
+INSERT INTO t1 VALUES (1,0);
+select * FROM t1;
+dim1	attr1
+1	0
+DROP TABLE t1;

--- a/mysql-test/mytile/t/encryption.test
+++ b/mysql-test/mytile/t/encryption.test
@@ -1,0 +1,12 @@
+--echo #
+--echo # The purpose of this test is to test encryption
+--echo #
+
+--echo # INTEGER
+CREATE TABLE t1 (
+  dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 integer
+) ENGINE=mytile encryption_key="testtesttesttesttesttesttesttest";
+INSERT INTO t1 VALUES (1,0);
+select * FROM t1;
+DROP TABLE t1;

--- a/mytile/mytile-discovery.h
+++ b/mytile/mytile-discovery.h
@@ -39,14 +39,12 @@
 namespace tile {
 /**
  * Helper function to do actual array discovery
- * @param hton
  * @param thd
  * @param ts
  * @param info
  * @return status
  */
-int discover_array(handlerton *hton, THD *thd, TABLE_SHARE *ts,
-                   HA_CREATE_INFO *info);
+int discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info);
 
 /**
  *

--- a/mytile/mytile.h
+++ b/mytile/mytile.h
@@ -19,6 +19,7 @@ struct ha_table_option_struct {
   ulonglong cell_order;
   ulonglong tile_order;
   ulonglong open_at;
+  const char *encryption_key;
 };
 
 /** Field options */


### PR DESCRIPTION
Support for creating, reading and writing encrypted arrays is included.

This includes minor modifications to create_array and discover_array in order to allow passing the encryption string to the handler.

Due to a limitation of MariaDB if you pass an encryption key it will be shown in the create table statement.

This will be rebased after #54 and #53 are merged.