### PR TITLE
Add support for filters in create table

### DIFF
--- a/mysql-test/mytile/r/filters.result
+++ b/mysql-test/mytile/r/filters.result
@@ -1,0 +1,81 @@
+#
+# The purpose of this test is to test create table with filters
+#
+CREATE TABLE t1 (
+dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 bigint filters='GZIP=6',
+attr2 bigint filters='GZIP=-1',
+attr3 bigint filters='GZIP=-1,ZSTD=6',
+attr4 bigint filters='BIT_WIDTH_REDUCTION=128',
+attr5 bigint filters='POSITIVE_DELTA=128',
+attr6 bigint filters='BIT_WIDTH_REDUCTION=138,ZSTD=1,GZIP=1',
+attr7 bigint filters='RLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0,100,200,300,400,500,600), (2,100,200,300,400,500,600,700), (3,200,300,400,500,600,700,800), (4,300,400,500,600,700,800,900);
+SELECT * FROM t1;
+dim1	attr1	attr2	attr3	attr4	attr5	attr6	attr7
+1	0	100	200	300	400	500	600
+2	100	200	300	400	500	600	700
+3	200	300	400	500	600	700	800
+4	300	400	500	600	700	800	900
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `dim1` bigint(20) DEFAULT NULL `dimension`=1 `lower_bound`='0' `upper_bound`='100' `tile_extent`='10',
+  `attr1` bigint(20) DEFAULT NULL `filters`='GZIP=6',
+  `attr2` bigint(20) DEFAULT NULL `filters`='GZIP=-1',
+  `attr3` bigint(20) DEFAULT NULL `filters`='GZIP=-1,ZSTD=6',
+  `attr4` bigint(20) DEFAULT NULL `filters`='BIT_WIDTH_REDUCTION=128',
+  `attr5` bigint(20) DEFAULT NULL `filters`='POSITIVE_DELTA=128',
+  `attr6` bigint(20) DEFAULT NULL `filters`='BIT_WIDTH_REDUCTION=138,ZSTD=1,GZIP=1',
+  `attr7` bigint(20) DEFAULT NULL `filters`='RLE'
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `coordinate_filters`='LZ4=-1' `offset_filters`='BZIP2=3'
+DROP TABLE t1;
+# Double Delta
+CREATE TABLE t1 (
+dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 bigint filters='DOUBLE_DELTA'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+dim1	attr1
+1	0
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `dim1` bigint(20) DEFAULT NULL `dimension`=1 `lower_bound`='0' `upper_bound`='100' `tile_extent`='10',
+  `attr1` bigint(20) DEFAULT NULL `filters`='DOUBLE_DELTA'
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `coordinate_filters`='LZ4=-1' `offset_filters`='BZIP2=3'
+DROP TABLE t1;
+# Bit Shuffle
+CREATE TABLE t1 (
+dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 bigint filters='BITSHUFFLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+dim1	attr1
+1	0
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `dim1` bigint(20) DEFAULT NULL `dimension`=1 `lower_bound`='0' `upper_bound`='100' `tile_extent`='10',
+  `attr1` bigint(20) DEFAULT NULL `filters`='BITSHUFFLE'
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `coordinate_filters`='LZ4=-1' `offset_filters`='BZIP2=3'
+DROP TABLE t1;
+# Byte Shuffle
+CREATE TABLE t1 (
+dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+attr1 bigint filters='BYTESHUFFLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+dim1	attr1
+1	0
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `dim1` bigint(20) DEFAULT NULL `dimension`=1 `lower_bound`='0' `upper_bound`='100' `tile_extent`='10',
+  `attr1` bigint(20) DEFAULT NULL `filters`='BYTESHUFFLE'
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `coordinate_filters`='LZ4=-1' `offset_filters`='BZIP2=3'
+DROP TABLE t1;

--- a/mysql-test/mytile/r/open_at.result
+++ b/mysql-test/mytile/r/open_at.result
@@ -11,7 +11,7 @@ quickstart_dense	CREATE TABLE `quickstart_dense` (
   `cols` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
   `a` int(11) DEFAULT NULL,
   PRIMARY KEY (`rows`,`cols`)
-) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `coordinate_filters`='ZSTD=-1' `offset_filters`='ZSTD=-1'
 show create table quickstart_dense_zero;
 Table	Create Table
 quickstart_dense_zero	CREATE TABLE `quickstart_dense_zero` (
@@ -19,7 +19,7 @@ quickstart_dense_zero	CREATE TABLE `quickstart_dense_zero` (
   `cols` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
   `a` int(11) DEFAULT NULL,
   PRIMARY KEY (`rows`,`cols`)
-) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `open_at`=0
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `open_at`=0 `coordinate_filters`='ZSTD=-1' `offset_filters`='ZSTD=-1'
 select * FROM quickstart_dense;
 rows	cols	a
 1	1	1

--- a/mysql-test/mytile/r/primary_key.result
+++ b/mysql-test/mytile/r/primary_key.result
@@ -9,7 +9,7 @@ quickstart_dense	CREATE TABLE `quickstart_dense` (
   `cols` int(11) NOT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
   `a` int(11) DEFAULT NULL,
   PRIMARY KEY (`rows`,`cols`)
-) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `coordinate_filters`='ZSTD=-1' `offset_filters`='ZSTD=-1'
 # Disable pushdown to force index scan
 SET mytile_enable_pushdown=0;
 explain SELECT * FROM quickstart_dense WHERE `rows` = 1 AND `cols` = 1 ORDER BY `rows`, `cols`;
@@ -26,7 +26,7 @@ quickstart_dense	CREATE TABLE `quickstart_dense` (
   `rows` int(11) DEFAULT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
   `cols` int(11) DEFAULT NULL `dimension`=1 `lower_bound`='1' `upper_bound`='4' `tile_extent`='4',
   `a` int(11) DEFAULT NULL
-) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR
+) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `coordinate_filters`='ZSTD=-1' `offset_filters`='ZSTD=-1'
 explain SELECT * FROM quickstart_dense WHERE `rows` = 1 AND `cols` = 1 ORDER BY `rows`, `cols`;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition

--- a/mysql-test/mytile/t/filters.test
+++ b/mysql-test/mytile/t/filters.test
@@ -1,0 +1,52 @@
+--echo #
+--echo # The purpose of this test is to test create table with filters
+--echo #
+
+CREATE TABLE t1 (
+  dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 bigint filters='GZIP=6',
+  attr2 bigint filters='GZIP=-1',
+  attr3 bigint filters='GZIP=-1,ZSTD=6',
+  attr4 bigint filters='BIT_WIDTH_REDUCTION=128',
+  attr5 bigint filters='POSITIVE_DELTA=128',
+  attr6 bigint filters='BIT_WIDTH_REDUCTION=138,ZSTD=1,GZIP=1',
+  attr7 bigint filters='RLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0,100,200,300,400,500,600), (2,100,200,300,400,500,600,700), (3,200,300,400,500,600,700,800), (4,300,400,500,600,700,800,900);
+SELECT * FROM t1;
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo # Double Delta
+CREATE TABLE t1 (
+  dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 bigint filters='DOUBLE_DELTA'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo # Bit Shuffle
+CREATE TABLE t1 (
+  dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 bigint filters='BITSHUFFLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo # Byte Shuffle
+CREATE TABLE t1 (
+  dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  attr1 bigint filters='BYTESHUFFLE'
+) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
+INSERT INTO t1 VALUES (1,0);
+SELECT * FROM t1;
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -185,6 +185,20 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
       table_options << " encryption_key=" << encryption_key;
     }
 
+    // Check for coordinate filters
+    tiledb::FilterList coordinate_filters = schema->coords_filter_list();
+    if (coordinate_filters.nfilters() > 0) {
+      table_options << " coordinate_filters='"
+                    << filter_list_to_str(coordinate_filters) << "'";
+    }
+
+    // Check for offset filters
+    tiledb::FilterList offset_filters = schema->offsets_filter_list();
+    if (offset_filters.nfilters() > 0) {
+      table_options << " offset_filters='" << filter_list_to_str(offset_filters)
+                    << "'";
+    }
+
     for (const auto &dim : schema->domain().dimensions()) {
       std::string domain_str = dim.domain_to_str();
       domain_str = domain_str.substr(1, domain_str.size() - 2);
@@ -226,6 +240,12 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
       if (!MysqlBlobType(enum_field_types(mysql_type)) &&
           TileDBTypeIsUnsigned(attribute.type()))
         sql_string << " UNSIGNED";
+
+      // Check for filters
+      tiledb::FilterList filters = attribute.filter_list();
+      if (filters.nfilters() > 0) {
+        sql_string << " filters='" << filter_list_to_str(filters) << "'";
+      }
       sql_string << ",";
     }
 

--- a/mytile/mytile.h
+++ b/mytile/mytile.h
@@ -20,6 +20,8 @@ struct ha_table_option_struct {
   ulonglong tile_order;
   ulonglong open_at;
   const char *encryption_key;
+  const char *coordinate_filters;
+  const char *offset_filters;
 };
 
 /** Field options */
@@ -28,6 +30,7 @@ struct ha_field_option_struct {
   const char *lower_bound;
   const char *upper_bound;
   const char *tile_extent;
+  const char *filters;
 };
 
 namespace tile {
@@ -354,6 +357,10 @@ int set_buffer_from_field(T val, std::shared_ptr<buffer> &buff, uint64_t i) {
 
 int set_buffer_from_field(Field *field, std::shared_ptr<buffer> &buff,
                           uint64_t i, THD *thd);
+
+tiledb::FilterList parse_filter_list(tiledb::Context &ctx,
+                                     const char *filter_csv);
+std::string filter_list_to_str(const tiledb::FilterList &filter_list);
 // -- end helpers --
 
 } // namespace tile


### PR DESCRIPTION
Filters are specified as a CSV list. For filters which take an option, i.e compressions, it is expected in the form `<FILTER_TYPE>=<OPTION_VALUE>` (`GZIP=6`)

Example create table statement:
```
CREATE TABLE t1 (
  dim1 bigint dimension=1 lower_bound="0" upper_bound="100" tile_extent="10",
  attr1 bigint filters='GZIP=6',
  attr2 bigint filters='GZIP=-1',
  attr3 bigint filters='GZIP=-1,ZSTD=6',
  attr4 bigint filters='BIT_WIDTH_REDUCTION=128',
  attr5 bigint filters='POSITIVE_DELTA=128',
  attr6 bigint filters='BIT_WIDTH_REDUCTION=138,ZSTD=1,GZIP=1',
  attr7 bigint filters='RLE'
) ENGINE=mytile coordinate_filters='LZ4=-1' offset_filters='BZIP2=3';
```