### PR TITLE
Fix handling discovery of TileDB Cloud Arrays

### DIFF
--- a/mytile/mytile-discovery.h
+++ b/mytile/mytile-discovery.h
@@ -85,4 +85,32 @@ int discover_array_metadata(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info,
                             const std::string &array_uri,
                             std::unique_ptr<tiledb::ArraySchema> schema,
                             const std::string &encryption_key);
+
+/**
+ * Check if an array exists
+ * @param vfs vfs object to use
+ * @param ctx context, only used if rest array
+ * @param array_uri uri to check if array exists
+ * @param encryption_key encryption key to use for rest array
+ * @param array_schema unique pointer where array schema will be stored if rest
+ * array
+ * @return true if array exists
+ */
+bool check_array_exists(const tiledb::VFS &vfs, const tiledb::Context &ctx,
+                        const std::string &array_uri,
+                        const std::string &encryption_key,
+                        std::unique_ptr<tiledb::ArraySchema> &array_schema);
+
+/**
+ * Check if an array exists with a tiledb:// uri
+ * @param ctx context
+ * @param array_uri uri to check if array exists
+ * @param encryption_key optional encryption key
+ * @param array_schema unique pointer where array schema will be stored
+ * @return true if array exists
+ */
+bool check_cloud_array_exists(
+    const tiledb::Context &ctx, const std::string &array_uri,
+    const std::string &encryption_key,
+    std::unique_ptr<tiledb::ArraySchema> &array_schema);
 } // namespace tile

--- a/mytile/utils.cc
+++ b/mytile/utils.cc
@@ -128,3 +128,11 @@ bool tile::has_ending(std::string const &s, std::string const &ending) {
     return false;
   }
 }
+
+bool tile::has_prefix(std::string const &s, std::string const &prefix) {
+  if (s.length() >= prefix.length()) {
+    return (0 == s.compare(0, prefix.length(), prefix));
+  } else {
+    return false;
+  }
+}

--- a/mytile/utils.h
+++ b/mytile/utils.h
@@ -147,4 +147,12 @@ void log_debug(THD *thd, const char *msg, ...);
  * @return true if s has the ending
  */
 bool has_ending(std::string const &s, std::string const &ending);
+
+/**
+ *
+ * @param s string to check against
+ * @param prefix prefix to check for
+ * @return true if s has prefix
+ */
+bool has_prefix(std::string const &s, std::string const &prefix);
 } // namespace tile


### PR DESCRIPTION
Fix handling discovery of TileDB Cloud Arrays. `tiledb://` arrays are not supported in vfs so we need to handle those by trying to load the array schema.