### PR TITLE
Update Dockerfile for TileDB 1.7.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.3.0"
+ARG MYTILE_VERSION="0.4.2"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.4 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -57,7 +57,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.4 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.3.0"
+ARG MYTILE_VERSION="0.4.2"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.4 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/mytile.cnf
+++ b/docker/mytile.cnf
@@ -23,3 +23,4 @@ language=/opt/server/share/english
 
 plugin_dir=/opt/server/lib/plugin
 plugin-maturity=experimental
+bind-address = 0.0.0.0


### PR DESCRIPTION
Update Dockerfile for TileDB 1.7.4 and also minor tweak to enforce tcp binding to 0.0.0.0 in docker images.