### PR TITLE
Fixes for a failure in table discovery

### DIFF
--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -186,7 +186,7 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
     if (schema->cell_order() == tiledb_layout_t::TILEDB_ROW_MAJOR) {
       table_options << " cell_order=ROW_MAJOR";
     } else if (schema->cell_order() == tiledb_layout_t::TILEDB_COL_MAJOR) {
-      table_options << " cell_order=COL_MAJOR";
+      table_options << " cell_order=COLUMN_MAJOR";
     } else {
       const char *layout;
       tiledb_layout_to_str(schema->cell_order(), &layout);
@@ -197,7 +197,7 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
     if (schema->tile_order() == tiledb_layout_t::TILEDB_ROW_MAJOR) {
       table_options << " tile_order=ROW_MAJOR";
     } else if (schema->tile_order() == tiledb_layout_t::TILEDB_COL_MAJOR) {
-      table_options << " tile_order=COL_MAJOR";
+      table_options << " tile_order=COLUMN_MAJOR";
     } else {
       const char *layout;
       tiledb_layout_to_str(schema->tile_order(), &layout);
@@ -355,7 +355,7 @@ int tile::discover_array_metadata(THD *thd, TABLE_SHARE *ts,
     if (schema->cell_order() == tiledb_layout_t::TILEDB_ROW_MAJOR) {
       table_options << " cell_order=ROW_MAJOR";
     } else if (schema->cell_order() == tiledb_layout_t::TILEDB_COL_MAJOR) {
-      table_options << " cell_order=COL_MAJOR";
+      table_options << " cell_order=COLUMN_MAJOR";
     } else {
       const char *layout;
       tiledb_layout_to_str(schema->cell_order(), &layout);
@@ -366,7 +366,7 @@ int tile::discover_array_metadata(THD *thd, TABLE_SHARE *ts,
     if (schema->tile_order() == tiledb_layout_t::TILEDB_ROW_MAJOR) {
       table_options << " tile_order=ROW_MAJOR";
     } else if (schema->tile_order() == tiledb_layout_t::TILEDB_COL_MAJOR) {
-      table_options << " tile_order=COL_MAJOR";
+      table_options << " tile_order=COLUMN_MAJOR";
     } else {
       const char *layout;
       tiledb_layout_to_str(schema->tile_order(), &layout);

--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -1015,6 +1015,7 @@ std::string tile::filter_list_to_str(const tiledb::FilterList &filter_list) {
     case TILEDB_FILTER_BITSHUFFLE:
     case TILEDB_FILTER_BYTESHUFFLE:
     case TILEDB_FILTER_DOUBLE_DELTA:
+      str << ",";
       break;
     // Handle all compressions with default
     default: {

--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -975,6 +975,8 @@ tiledb::FilterList tile::parse_filter_list(tiledb::Context &ctx,
       case TILEDB_FILTER_BITSHUFFLE:
       case TILEDB_FILTER_BYTESHUFFLE:
       case TILEDB_FILTER_DOUBLE_DELTA:
+      case TILEDB_FILTER_CHECKSUM_MD5:
+      case TILEDB_FILTER_CHECKSUM_SHA256:
         break;
       // Handle all compressions with default
       default: {
@@ -1015,6 +1017,8 @@ std::string tile::filter_list_to_str(const tiledb::FilterList &filter_list) {
     case TILEDB_FILTER_BITSHUFFLE:
     case TILEDB_FILTER_BYTESHUFFLE:
     case TILEDB_FILTER_DOUBLE_DELTA:
+    case TILEDB_FILTER_CHECKSUM_MD5:
+    case TILEDB_FILTER_CHECKSUM_SHA256:
       str << ",";
       break;
     // Handle all compressions with default


### PR DESCRIPTION
This fixes two problems encountered with an array. First we were not handling Byte/BitShuffle and Double Delta filters properly for filter lists. Second problem was the table discovery was using the wrong string for COLUMN_MAJOR order. It needed to line up with the [table options](https://github.com/TileDB-Inc/TileDB-MariaDB/blob/c7f0949976db92e7e64899af941b7194660698d0/mytile/ha_mytile.cc#L63)