### PR TITLE
Update to TileDB 1.7.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         CXX: g++
       macOS:
-        imageName: 'macOS-10.13'
+        imageName: 'macOS-10.14'
         CXX: clang++
 
   pool:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -57,7 +57,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -10,6 +10,13 @@ steps:
   displayName: 'Print env'
 
 - bash: |
+    set -e pipefail
+    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+    sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  displayName: 'Install system headers (OSX only)'
+
+- bash: |
     set -e
     # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969
     if [[ "$AGENT_OS" == "Linux" ]]; then
@@ -38,8 +45,6 @@ steps:
 
     if [[ "$AGENT_OS" == "Darwin" ]]; then
       brew install cmake jemalloc traildb/judy/judy openssl boost gnutls
-      #open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
-      #sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
       export OSX_FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error"
       export CXXFLAGS="${CXXFLAGS} ${OSX_FLAGS_NEEDED}"
       export CFLAGS="${CFLAGS} ${OSX_FLAGS_NEEDED}"

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -11,9 +11,9 @@ mv !(tmp) tmp # Move everything but tmp
 wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz
 tar xf ${MARIADB_VERSION}.tar.gz
 
-# Install tiledb using 1.7.2 release
+# Install tiledb using 1.7.6 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.2 && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
 && mkdir -p build && cd build
 
 # Configure and build TileDB


### PR DESCRIPTION
This updates CI and the docker files. TileDB <1.7.6 has broken builds due to tbb changing their repo name.