### PR TITLE
Update to TileDB 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,13 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     MESSAGE(STATUS "TileDB not found for MyTile. Building as depedency from source")
     include(ExternalProject)
 
-    SET(TILEDB_VERSION "1.6.3")
+    SET(TILEDB_VERSION "2.0.0")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb
             PREFIX "externals"
             URL "https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.zip"
-            URL_HASH SHA1=967f23e8cd0b4474457c88ad9bcbebdb1b7e626b
+	    URL_HASH SHA1=26488afa4fc90bf1cbc4377f3ea1b5953abed8b4
             DOWNLOAD_NAME "tiledb.zip"
             CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.3.0"
+ARG MYTILE_VERSION="0.5.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -70,9 +70,9 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 RUN git config --global user.email "you@example.com" \
  && git config --global user.name "Your Name"
 
-# Install tiledb using 1.7 release
+# Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -55,9 +55,9 @@ WORKDIR /tmp
 RUN git config --global user.email "you@example.com" \
  && git config --global user.name "Your Name"
 
-# Install tiledb using 1.7 release
+# Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -53,7 +53,7 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.11"
 
-ARG MYTILE_VERSION="0.3.0"
+ARG MYTILE_VERSION="master"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -70,9 +70,9 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 RUN git config --global user.email "you@example.com" \
  && git config --global user.name "Your Name"
 
-# Install tiledb using 1.7 release
+# Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 1.7.6 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -11,9 +11,9 @@ mv !(tmp) tmp # Move everything but tmp
 wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz
 tar xf ${MARIADB_VERSION}.tar.gz
 
-# Install tiledb using 2.0.0-rc4 release
+# Install tiledb using 2.0.0 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b dev && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
 && mkdir -p build && cd build
 
 # Configure and build TileDB


### PR DESCRIPTION
Update to TileDB 2.0.0 for CI, docker and superbuild (which doesn't really work).