### PR TITLE
Correct MRR support with start/end keys

### DIFF
--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -574,10 +574,11 @@ private:
    * Reset condition pushdowns to be for key conditions
    * @param key key(s) to pushdown
    * @param key_len
+   * @param start_key is key start key
    * @param find_flag equality condition of last key
    * @return
    */
-  int reset_pushdowns_for_key(const uchar *key, uint key_len,
+  int reset_pushdowns_for_key(const uchar *key, uint key_len, bool start_key,
                               enum ha_rkey_function find_flag);
 
   /**


### PR DESCRIPTION
The find_flag from the key has different meanings for if it from a start key or an end key.

This should fix the issue with MariaDB 10.4.12/13 now that the MRR call path is called more often thanks to https://github.com/MariaDB/server/commit/1242eb3d32f2863f847aa96a10e2ab983a1a643b