### PR TITLE
Update MariaDB for CI and Docker to 10.4.13 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     MESSAGE(STATUS "TileDB not found for MyTile. Building as depedency from source")
     include(ExternalProject)
 
-    SET(TILEDB_VERSION "2.0.0")
+    SET(TILEDB_VERSION "2.0.2")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,9 +51,9 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
-ENV MARIADB_VERSION="mariadb-10.4.11"
+ENV MARIADB_VERSION="mariadb-10.4.13"
 
-ARG MYTILE_VERSION="0.5.0"
+ARG MYTILE_VERSION="0.5.4"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -57,7 +57,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y \
   libcurl4-openssl-dev \
   && rm -rf /var/lib/apt/lists/*
 
-ENV MARIADB_VERSION="mariadb-10.4.11"
+ENV MARIADB_VERSION="mariadb-10.4.13"
 
 ADD . /tmp/mytile
 

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -51,9 +51,9 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
-ENV MARIADB_VERSION="mariadb-10.4.11"
+ENV MARIADB_VERSION="mariadb-10.4.13"
 
-ARG MYTILE_VERSION="master"
+ARG MYTILE_VERSION="0.5.4"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -72,7 +72,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.2 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -45,7 +45,7 @@ steps:
 
     if [[ "$AGENT_OS" == "Darwin" ]]; then
       brew install cmake jemalloc traildb/judy/judy openssl boost gnutls
-      export OSX_FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error"
+      export OSX_FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error -Wno-error=pointer-sign"
       export CXXFLAGS="${CXXFLAGS} ${OSX_FLAGS_NEEDED}"
       export CFLAGS="${CFLAGS} ${OSX_FLAGS_NEEDED}"
       export DYLD_LIBRARY_PATH=$BUILD_REPOSITORY_LOCALPATH/build_deps/TileDB/dist/lib:$DYLD_LIBRARY_PATH

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -3,7 +3,7 @@
 set -v -e -x
 
 original_dir=$PWD
-export MARIADB_VERSION="mariadb-10.4.11"
+export MARIADB_VERSION="mariadb-10.4.13"
 mkdir tmp
 shopt -s extglob
 mv !(tmp) tmp # Move everything but tmp

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -10,9 +10,9 @@ mv !(tmp) tmp # Move everything but tmp
 # Download mariadb using git, this has a habit of failing so let's do it first
 git clone https://github.com/MariaDB/server.git -b ${MARIADB_VERSION} ${MARIADB_VERSION}
 
-# Install tiledb using 2.0.0 release
+# Install tiledb using 2.0.2 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.0 && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.2 && cd TileDB \
 && mkdir -p build && cd build
 
 # Configure and build TileDB


### PR DESCRIPTION
This updates the MariaDB version to the latest for 10.4. We also update TileDB to 2.0.2.