### PR TITLE
Add support for duplicates in sparse arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,22 +102,6 @@ Once MariaDB has been build you can run unit tests from the build directory:
 
 That will run all unit tests defined for mytile
 
-## Parameters
-
-There are three parameters currently supported for MyTile.
-
-| Paramater | Scope | Data Type | Default Value | Description |
-| --------- | ----- | --------- | ------------- | ----------- |
-| read_buffer_size | global or session | integer | 100M | Read buffer size for tiledb query attribute/coordinates |
-| write_buffer_size | global or session | integer | 100M | Write buffer size for tiledb query attribute/coordinates |
-| delete_arrays | global or session | boolean | False | Controls if a `delete table` statement causes the array to be deleted on disk or just deregistered from mariadb. True value causes actual deletions of data |
-| tiledb_config* | global or session | string | "" | Set TileDB configuration parameters, this is in csv form of `key1=value1,key2=value2`. Example: `set mytile_tiledb_config = 'vfs.s3.aws_access_key_id=abc,vfs.s3.aws_secret_access_key=123';` |
-| reopen_for_every_query | global or session | boolean | True | Closes and reopen the array for every query, this allows tiledb_config parameters to take effect without forcing a table flush but any tiledb caching is removed. |
-| ready_query_layout | global or session | string | "unordered" | set layout for ready queries, valid values are "row-major", "col-major", "unordered" or "global-order" |
-
-\* If reopen_for_every_query is disabled you must `FLUSH TABLES` before any new parameters set on `tiledb_config`
-will take effect on an open array (recently access arrays are not closed by MariaDB immediately).
-
 ## Features
 
 - Based on TileDB arrays
@@ -131,4 +115,3 @@ will take effect on an open array (recently access arrays are not closed by Mari
 - Condition pushdown only works for constants not sub selects
 - Buffers will double in size for incomplete queries with zero results
 - MyTile is not capable of binlogging currently both stmt and row based is disabled at the storage engine level
-- Specifying filters in create table is not supported, all filters default to zstd

--- a/mysql-test/mytile/r/duplicates.result
+++ b/mysql-test/mytile/r/duplicates.result
@@ -1,0 +1,38 @@
+#
+# The purpose of this test is to validate sparse arrays will support duplicates
+#
+# No key should allow duplicates
+CREATE TABLE t1 (
+dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+attr1 integer
+) ENGINE=mytile;
+INSERT INTO t1 VALUES (1, 1), (1, 2);
+select * FROM t1;
+dim1	attr1
+1	1
+1	2
+DROP TABLE t1;
+# Index should allow duplicates
+CREATE TABLE t2 (
+dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+attr1 integer,
+INDEX(dim1)
+) ENGINE=mytile;
+INSERT INTO t2 VALUES (1, 10), (1, 20);
+select * FROM t2;
+dim1	attr1
+1	10
+1	20
+DROP TABLE t2;
+# Primary key should not allow duplicates
+CREATE TABLE t3 (
+dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+attr1 integer,
+PRIMARY KEY(dim1)
+) ENGINE=mytile;
+INSERT INTO t3 VALUES (1, 10);
+INSERT INTO t3 VALUES (1, 20);
+select * FROM t3;
+dim1	attr1
+1	20
+DROP TABLE t3;

--- a/mysql-test/mytile/r/flushing_arrays.result
+++ b/mysql-test/mytile/r/flushing_arrays.result
@@ -4,7 +4,7 @@
 # Setup existing array first
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 # Create test array
-CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", `cols` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", a INTEGER unsigned) ENGINE=MyTile;
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", `cols` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", a INTEGER unsigned) ENGINE=MyTile ARRAY_TYPE=DENSE;
 # Start with no tables open
 FLUSH TABLES;
 # Test with mytile_reopen_for_every_query=1

--- a/mysql-test/mytile/r/join.result
+++ b/mysql-test/mytile/r/join.result
@@ -27,7 +27,7 @@ rows	cols	a	a
 4	4	16	16
 set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
-set mytile_dimensions_are_primary_keys=0;
+set mytile_dimensions_are_keys=0;
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 # Block Nested Loop Join Explain
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;

--- a/mysql-test/mytile/r/primary_key.result
+++ b/mysql-test/mytile/r/primary_key.result
@@ -18,7 +18,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 SET mytile_enable_pushdown=1;
 SET mytile_delete_arrays=0;
 DROP TABLE `quickstart_dense`;
-SET mytile_dimensions_are_primary_keys=0;
+SET mytile_dimensions_are_keys=0;
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 show create table quickstart_dense;
 Table	Create Table
@@ -32,7 +32,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
 DROP TABLE `quickstart_dense`;
 set mytile_delete_arrays=1;
-SET mytile_dimensions_are_primary_keys=1;
+SET mytile_dimensions_are_keys=1;
 #
 # The purpose of this test is to validate pushed ranges
 #

--- a/mysql-test/mytile/t/duplicates.test
+++ b/mysql-test/mytile/t/duplicates.test
@@ -1,0 +1,33 @@
+--echo #
+--echo # The purpose of this test is to validate sparse arrays will support duplicates
+--echo #
+
+--echo # No key should allow duplicates
+CREATE TABLE t1 (
+  dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+  attr1 integer
+) ENGINE=mytile;
+INSERT INTO t1 VALUES (1, 1), (1, 2);
+select * FROM t1;
+DROP TABLE t1;
+
+--echo # Index should allow duplicates
+CREATE TABLE t2 (
+  dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+  attr1 integer,
+  INDEX(dim1)
+) ENGINE=mytile;
+INSERT INTO t2 VALUES (1, 10), (1, 20);
+select * FROM t2;
+DROP TABLE t2;
+
+--echo # Primary key should not allow duplicates
+CREATE TABLE t3 (
+  dim1 integer dimension=1 lower_bound="0" upper_bound="100" tile_extent="10" NOT NULL,
+  attr1 integer,
+  PRIMARY KEY(dim1)
+) ENGINE=mytile;
+INSERT INTO t3 VALUES (1, 10);
+INSERT INTO t3 VALUES (1, 20);
+select * FROM t3;
+DROP TABLE t3;

--- a/mysql-test/mytile/t/flushing_arrays.test
+++ b/mysql-test/mytile/t/flushing_arrays.test
@@ -8,7 +8,7 @@
 
 
 --echo # Create test array
-CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", `cols` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", a INTEGER unsigned) ENGINE=MyTile;
+CREATE TABLE quickstart_dense_2 (`rows` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", `cols` INTEGER DIMENSION=1 `lower_bound`='0' `upper_bound`='1024' tile_extent="100", a INTEGER unsigned) ENGINE=MyTile ARRAY_TYPE=DENSE;
 
 --echo # Start with no tables open
 FLUSH TABLES;

--- a/mysql-test/mytile/t/join.test
+++ b/mysql-test/mytile/t/join.test
@@ -15,7 +15,7 @@ select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols
 set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
 
-set mytile_dimensions_are_primary_keys=0;
+set mytile_dimensions_are_keys=0;
 
 --replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';

--- a/mysql-test/mytile/t/primary_key.test
+++ b/mysql-test/mytile/t/primary_key.test
@@ -16,7 +16,7 @@ SET mytile_enable_pushdown=1;
 SET mytile_delete_arrays=0;
 DROP TABLE `quickstart_dense`;
 
-SET mytile_dimensions_are_primary_keys=0;
+SET mytile_dimensions_are_keys=0;
 --replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
 
@@ -28,7 +28,7 @@ explain SELECT * FROM quickstart_dense WHERE `rows` = 1 AND `cols` = 1 ORDER BY 
 DROP TABLE `quickstart_dense`;
 
 set mytile_delete_arrays=1;
-SET mytile_dimensions_are_primary_keys=1;
+SET mytile_dimensions_are_keys=1;
 
 --echo #
 --echo # The purpose of this test is to validate pushed ranges

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -59,8 +59,7 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
   std::string array_uri;
   std::unique_ptr<tiledb::ArraySchema> schema;
 
-  bool dimensions_are_keys =
-      tile::sysvars::dimensions_are_keys(thd);
+  bool dimensions_are_keys = tile::sysvars::dimensions_are_keys(thd);
 
   std::string encryption_key;
   if (info != nullptr && info->option_struct != nullptr &&
@@ -297,6 +296,9 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
       // In the future we might want to set index instead of primary key when
       // TileDB supports duplicates
       std::vector<std::string> index_types = {"PRIMARY KEY"};
+      if (schema->allows_dups()) {
+        index_types = {"INDEX"};
+      }
       for (auto &index_type : index_types) {
         sql_string << std::endl << index_type << "(";
         for (const auto &dim : schema->domain().dimensions()) {

--- a/mytile/mytile-discovery.cc
+++ b/mytile/mytile-discovery.cc
@@ -59,8 +59,8 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
   std::string array_uri;
   std::unique_ptr<tiledb::ArraySchema> schema;
 
-  bool dimensions_are_primary_keys =
-      tile::sysvars::dimensions_are_primary_keys(thd);
+  bool dimensions_are_keys =
+      tile::sysvars::dimensions_are_keys(thd);
 
   std::string encryption_key;
   if (info != nullptr && info->option_struct != nullptr &&
@@ -293,7 +293,7 @@ int tile::discover_array(THD *thd, TABLE_SHARE *ts, HA_CREATE_INFO *info) {
     }
 
     // Add primary key indicator
-    if (dimensions_are_primary_keys) {
+    if (dimensions_are_keys) {
       // In the future we might want to set index instead of primary key when
       // TileDB supports duplicates
       std::vector<std::string> index_types = {"PRIMARY KEY"};

--- a/mytile/mytile-sysvars.cc
+++ b/mytile/mytile-sysvars.cc
@@ -84,7 +84,7 @@ static MYSQL_THDVAR_ENUM(read_query_layout, PLUGIN_VAR_OPCMDARG,
                          &query_layout_typelib);
 
 // Dimensions as primary keys
-static MYSQL_THDVAR_BOOL(dimensions_are_primary_keys,
+static MYSQL_THDVAR_BOOL(dimensions_are_keys,
                          PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_THDLOCAL,
                          "Should dimension be treated as primary keys", NULL,
                          NULL, true);
@@ -119,7 +119,7 @@ struct st_mysql_sys_var *mytile_system_variables[] = {
     MYSQL_SYSVAR(tiledb_config),
     MYSQL_SYSVAR(reopen_for_every_query),
     MYSQL_SYSVAR(read_query_layout),
-    MYSQL_SYSVAR(dimensions_are_primary_keys),
+    MYSQL_SYSVAR(dimensions_are_keys),
     MYSQL_SYSVAR(enable_pushdown),
     MYSQL_SYSVAR(compute_table_records),
     MYSQL_SYSVAR(log_level),
@@ -146,8 +146,8 @@ tiledb_layout_t read_query_layout(THD *thd) {
   return query_layout;
 }
 
-my_bool dimensions_are_primary_keys(THD *thd) {
-  return THDVAR(thd, dimensions_are_primary_keys);
+my_bool dimensions_are_keys(THD *thd) {
+  return THDVAR(thd, dimensions_are_keys);
 }
 
 my_bool enable_pushdown(THD *thd) { return THDVAR(thd, enable_pushdown); }

--- a/mytile/mytile-sysvars.h
+++ b/mytile/mytile-sysvars.h
@@ -59,7 +59,7 @@ my_bool reopen_for_every_query(THD *thd);
 
 tiledb_layout_t read_query_layout(THD *thd);
 
-my_bool dimensions_are_primary_keys(THD *thd);
+my_bool dimensions_are_keys(THD *thd);
 
 my_bool enable_pushdown(THD *thd);
 


### PR DESCRIPTION
This adds support for duplicate in arrays. A new option for sparse arrays in TileDB 2.0 is to allow duplicates. We now will switch between primary key and index on table discovery and when creating the array we check for if the user specified the primary key (no duplicates) or not (duplicates allowed if sparse).