### PR TITLE
Update to TileDB 2.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,13 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     MESSAGE(STATUS "TileDB not found for MyTile. Building as depedency from source")
     include(ExternalProject)
 
-    SET(TILEDB_VERSION "2.0.2")
+    SET(TILEDB_VERSION "2.0.5")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb
             PREFIX "externals"
             URL "https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.zip"
-	    URL_HASH SHA1=26488afa4fc90bf1cbc4377f3ea1b5953abed8b4
+	    URL_HASH SHA1=2ea02e466bec14a30f82b618387d066551e432ff
             DOWNLOAD_NAME "tiledb.zip"
             CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}
@@ -73,6 +73,7 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
             LOG_CONFIGURE TRUE
             LOG_BUILD TRUE
             LOG_INSTALL TRUE
+	    LOG_OUTPUT_ON_FAILURE TRUE
             )
 
     # Manually link library

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.3 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -58,7 +58,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.3 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -73,7 +73,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.3 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -12,12 +12,12 @@ git clone https://github.com/MariaDB/server.git -b ${MARIADB_VERSION} ${MARIADB_
 
 # Install TileDB using 2.0 release
 mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.3 && cd TileDB \
+&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
 && mkdir -p build && cd build
 
 # Configure and build TileDB
 cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug .. \
-&& make -j4 \
+&& make -j$(nproc) \
 && sudo make -C tiledb install \
 && cd $original_dir
 


### PR DESCRIPTION
Update to TileDB 2.0.5, specifically this fixes the problem with [GCS causing context to fail to start](https://github.com/TileDB-Inc/TileDB/pull/1667).

We'll cut a new release after this to update the docker and conda packages.