### PR TITLE
Fix readme docker links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MyTile
 
 [![Build Status](https://img.shields.io/azure-devops/build/tiledb-inc/836549eb-f74a-4986-a18f-7fbba6bbb5f0/8?label=Azure%20Pipelines&logo=azure-pipelines&style=flat-square)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=10&branchName=master)
-[![tiledb-mariadb](https://img.shields.io/static/v1?label=Docker&message=tiledb-mariadb&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/repository/docker/tiledb/tiledb-mariadb)
-[![tiledb-mariadb-server](https://img.shields.io/static/v1?label=Docker&message=tiledb-mariadb-server&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/repository/docker/tiledb/tiledb-mariadb-server)
+[![tiledb-mariadb](https://img.shields.io/static/v1?label=Docker&message=tiledb-mariadb&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/r/tiledb/tiledb-mariadb)
+[![tiledb-mariadb-server](https://img.shields.io/static/v1?label=Docker&message=tiledb-mariadb-server&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/r/tiledb/tiledb-mariadb-server)
 
 MariaDB storage engine based on [TileDB](https://tiledb.com).
 
@@ -10,7 +10,7 @@ MariaDB storage engine based on [TileDB](https://tiledb.com).
 
 ### Docker
 
-Docker images are available on [Docker Hub]() for quick testing of the mytile storage engine.
+Docker images are available on [Docker Hub](https://hub.docker.com/u/tiledb) for quick testing of the mytile storage engine.
 
 #### Variants
 


### PR DESCRIPTION
`https://hub.docker.com/r` is the public URL for a repo whereas `https://hub.docker.com/repository/docker` requires a login.