### PR TITLE
Update CI to build proper Docker Image versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,39 +6,43 @@ trigger:
     include:
     - "*"
 
-jobs:
-- job: Build
-  strategy:
-    matrix:
-      linux:
-        imageName: 'ubuntu-16.04'
-        CXX: g++
-      macOS:
-        imageName: 'macOS-10.14'
-        CXX: clang++
+stages:
+  - stage: CI
+    condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-')))
+    jobs:
+    - job: Build
+      strategy:
+        matrix:
+          linux:
+            imageName: 'ubuntu-16.04'
+            CXX: g++
+          macOS:
+            imageName: 'macOS-10.14'
+            CXX: clang++
 
-  pool:
-    vmImage: $(imageName)
-  steps:
-  - template: scripts/azure-linux_mac.yml
+      pool:
+        vmImage: $(imageName)
+      steps:
+      - template: scripts/azure-linux_mac.yml
 
-- job: Docker
-  dependsOn: Build
-  condition: succeeded()
 
-  pool:
-    vmImage: 'ubuntu-18.04'
+  - stage: Docker
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    jobs:
+    - job: Docker
+      pool:
+        vmImage: 'ubuntu-18.04'
 
-  strategy:
-    matrix:
-      tiledb-mariadb:
-        dockerfile: docker/Dockerfile
-        repository: tiledb/tiledb-mariadb
-        context: .
-      tiledb-mariadb-server:
-        dockerfile: docker/Dockerfile
-        repository: tiledb/tiledb-mariadb-server
-        context: .
+      strategy:
+        matrix:
+          tiledb-mariadb:
+            dockerfile: docker/Dockerfile
+            repository: tiledb/tiledb-mariadb
+            context: .
+          tiledb-mariadb-server:
+            dockerfile: docker/Dockerfile
+            repository: tiledb/tiledb-mariadb-server
+            context: .
 
-  steps:
-  - template: scripts/build-images.yml
+      steps:
+      - template: scripts/build-images.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,9 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.13"
 
-ARG MYTILE_VERSION="0.5.4"
+ARG MYTILE_VERSION="0.5.9"
+
+ARG TILEDB_VERSION="2.0.5"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -73,7 +75,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b ${TILEDB_VERSION} && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -50,6 +50,8 @@ RUN apt-get update && apt-get install -y \
 
 ENV MTR_MEM /tmp
 
+ARG TILEDB_VERSION="2.0.5"
+
 WORKDIR /tmp
 
 # Set git config so superbuild of tiledb can cherry-pick capnp fix
@@ -58,7 +60,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b ${TILEDB_VERSION} && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -54,7 +54,9 @@ WORKDIR /tmp
 
 ENV MARIADB_VERSION="mariadb-10.4.13"
 
-ARG MYTILE_VERSION="0.5.4"
+ARG MYTILE_VERSION="0.5.9"
+
+ARG TILEDB_VERSION="2.0.5"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -73,7 +75,7 @@ RUN git config --global user.email "you@example.com" \
 
 # Install tiledb using 2.0 release
 RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.5 && cd TileDB \
+ && git clone https://github.com/TileDB-Inc/TileDB.git -b ${TILEDB_VERSION} && cd TileDB \
  && mkdir -p build && cd build \
  && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
  && make -j$(nproc) \

--- a/scripts/build-images.yml
+++ b/scripts/build-images.yml
@@ -7,6 +7,7 @@ steps:
       repository: $(repository)
       Dockerfile: $(dockerfile)
       buildContext: $(context)
+      arguments: '--build-arg MYTILE_VERSION=$(build.SourceBranchName)'
       tags: |
         dev
         latest
@@ -29,6 +30,5 @@ steps:
       containerRegistry: 'dockerHub'
       repository: $(repository)
       tags: |
-        dev
         latest
         $(build.SourceBranchName)


### PR DESCRIPTION
Previously the build-arg for docker build was missing to set the mytile version.

We also introduce a new TILEDB_VERSION arg for flexibility