### PR TITLE
Disable AWS SDK from using EC2 metadata in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="support@tiledb.io"
 
-#RUN apt-get update && apt install -y software-properties-common python-software-properties curl
+ENV AWS_EC2_METADATA_DISABLED true
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=GMT

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="support@tiledb.io"
 
-#RUN apt-get update && apt install -y software-properties-common python-software-properties curl
+ENV AWS_EC2_METADATA_DISABLED true
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=GMT

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="support@tiledb.io"
 
-#RUN apt-get update && apt install -y software-properties-common python-software-properties curl
+ENV AWS_EC2_METADATA_DISABLED true
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=GMT


### PR DESCRIPTION
If a user tries to access the AWS S3 arrays but doesn't provide credentials (such as using a public dataset) the SDK tries to lookup
credentials with EC2 metadata IP and this causes a long timeout for curl.