### PR TITLE
Improve superbuild library copying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,16 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     MESSAGE(STATUS "TileDB not found for MyTile. Building as depedency from source")
     include(ExternalProject)
 
-    SET(TILEDB_VERSION "2.0.8")
+    SET(TILEDB_VERSION_MAJOR "2")
+    SET(TILEDB_VERSION_MINOR "0")
+    SET(TILEDB_VERSION_PATCH "8")
+    SET(TILEDB_VERSION "${TILEDB_VERSION_MAJOR}.${TILEDB_VERSION_MINOR}.${TILEDB_VERSION_PATCH}")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb
             PREFIX "externals"
             URL "https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.zip"
-	    URL_HASH SHA1=f0ba8f768aafe844530f85f3c8b51ac2d27d7194
+            URL_HASH SHA1=f0ba8f768aafe844530f85f3c8b51ac2d27d7194
             DOWNLOAD_NAME "tiledb.zip"
             CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}
@@ -73,14 +76,14 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
             LOG_CONFIGURE TRUE
             LOG_BUILD TRUE
             LOG_INSTALL TRUE
-	    LOG_OUTPUT_ON_FAILURE TRUE
+            LOG_OUTPUT_ON_FAILURE TRUE
             )
 
     # Manually link library
     # Must use full library name else cmake things its the external target of `tiledb`
 #    SET(TILEDB_LIBRARIES "${EP_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}tiledb${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    SET(TILEDB_LIBRARIES "${EP_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}tiledb${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    FILE(GLOB TILEDB_INSTALL_LIBRARIES "${EP_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libtiledb*")
+    SET(TILEDB_LIBRARIES "${EP_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}tiledb${CMAKE_SHARED_LIBRARY_SUFFIX}.${TILEDB_VERSION_MAJOR}.${TILEDB_VERSION_MINOR}")
+    FILE(GLOB TILEDB_INSTALL_LIBRARIES "${TILEDB_LIBRARIES}")
 else()
     # First check for release lib details
     GET_TARGET_PROPERTY(TILEDB_LIBRARIES TileDB::tiledb_shared IMPORTED_LOCATION_RELEASE)
@@ -101,7 +104,7 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     # when building, don't use the install RPATH already
     # (but later on when installing)
     SET(PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_PLUGINDIR}")
-    SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
     SET(CMAKE_INSTALL_RPATH "${PLUGIN_INSTALL_DIR}")
 
     # add the automatically determined parts of the RPATH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,10 @@ stages:
           linux:
             imageName: 'ubuntu-16.04'
             CXX: g++
+          linux_superbuild:
+            imageName: 'ubuntu-16.04'
+            CXX: g++
+            SUPERBUILD: 'ON'
           macOS:
             imageName: 'macOS-10.14'
             CXX: clang++

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -50,8 +50,6 @@ steps:
       export CFLAGS="${CFLAGS} ${OSX_FLAGS_NEEDED}"
       export DYLD_LIBRARY_PATH=$BUILD_REPOSITORY_LOCALPATH/build_deps/TileDB/dist/lib:$DYLD_LIBRARY_PATH
     fi
-    # source ./scripts/ci_install_tiledb.sh
-    # source ./scripts/ci_tests.sh
     source ./scripts/ci_install_tiledb_and_run_tests.sh
 
     #  displayName: 'Build examples, PNG test, and benchmarks (build-only)'

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -11,15 +11,21 @@ mv !(tmp) tmp # Move everything but tmp
 git clone https://github.com/MariaDB/server.git -b ${MARIADB_VERSION} ${MARIADB_VERSION}
 
 # Install TileDB using 2.0 release
-mkdir build_deps && cd build_deps \
-&& git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.8 && cd TileDB \
-&& mkdir -p build && cd build
+if [[ -z ${SUPERBUILD+x} || "${SUPERBUILD}" == "OFF" ]]; then
+  mkdir build_deps && cd build_deps \
+  && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.0.8 && cd TileDB \
+  && mkdir -p build && cd build
 
-# Configure and build TileDB
-cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug .. \
-&& make -j$(nproc) \
-&& sudo make -C tiledb install \
-&& cd $original_dir
+   # Configure and build TileDB
+   cmake -DTILEDB_VERBOSE=ON -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Debug .. \
+   && make -j$(nproc) \
+   && sudo make -C tiledb install \
+   && cd $original_dir
+else # set superbuild flags
+  export SUPERBUILD_FLAGS_NEEDED="-Wno-error=deprecated-declarations"
+  export CXXFLAGS="${CXXFLAGS} ${SUPERBUILD_FLAGS_NEEDED}"
+  export CFLAGS="${CFLAGS} ${SUPERBUILD_FLAGS_NEEDED}"
+fi
 
 mv tmp ${MARIADB_VERSION}/storage/mytile \
 && cd ${MARIADB_VERSION} \


### PR DESCRIPTION
When building TileDB from source we now properly copy over the non-symlinked library.