### PR TITLE
use 0 for default float / double nan fill values

### DIFF
--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -275,10 +275,16 @@ std::string tile::TileDBTypeValueToString(tiledb_datatype_t type,
     }
     case TILEDB_FLOAT32: {
       auto v = static_cast<const float*>(value);
+      if (std::isnan(*v)) {
+        return std::to_string(0.0f);
+      }
       return std::to_string(*v);
     }
     case TILEDB_FLOAT64: {
       auto v = static_cast<const double*>(value);
+      if (std::isnan(*v)) {
+        return std::to_string(0.0f);
+      }
       return std::to_string(*v);
     }
     case TILEDB_DATETIME_YEAR:


### PR DESCRIPTION
Array discovery is using NaN for float / double values as retrieved from get_fill_value. This change detects that and uses 0.0 instead.