### PR TITLE
Add support for subsetting an array on discovery

### DIFF
--- a/mysql-test/mytile/r/create_allow_subset_existing_array.result
+++ b/mysql-test/mytile/r/create_allow_subset_existing_array.result
@@ -1,0 +1,49 @@
+#
+# The purpose of this test is to subset the columns on an existing array
+#
+call mtr.add_suppression("\\[ERROR\\] (mysqld|mariadbd): Error in creating table \\[TileDB::ArraySchema\\] Error: Cannot set domain; Domain must contain at least one dimension");
+CREATE TABLE t1 (a int) ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+ERROR HY000: Error in creating table [TileDB::ArraySchema] Error: Cannot set domain; Domain must contain at least one dimension
+SET mytile_delete_arrays=0;
+SET mytile_create_allow_subset_existing_array=1;
+CREATE TABLE t1 (a int) ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+select * from t1;
+a
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+drop table t1;
+CREATE TABLE t1 (`rows` float, a int) ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
+select * from t1;
+rows	a
+1	1
+1	2
+1	3
+1	4
+2	5
+2	6
+2	7
+2	8
+3	9
+3	10
+3	11
+3	12
+4	13
+4	14
+4	15
+4	16
+drop table t1;
+SET mytile_create_allow_subset_existing_array=0;

--- a/mysql-test/mytile/t/create_allow_subset_existing_array.test
+++ b/mysql-test/mytile/t/create_allow_subset_existing_array.test
@@ -1,0 +1,24 @@
+--echo #
+--echo # The purpose of this test is to subset the columns on an existing array
+--echo #
+
+call mtr.add_suppression("\\[ERROR\\] (mysqld|mariadbd): Error in creating table \\[TileDB::ArraySchema\\] Error: Cannot set domain; Domain must contain at least one dimension");
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--error ER_UNKNOWN_ERROR
+--eval CREATE TABLE t1 (a int) ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+SET mytile_delete_arrays=0;
+SET mytile_create_allow_subset_existing_array=1;
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE t1 (a int) ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+select * from t1;
+drop table t1;
+
+--replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
+--eval CREATE TABLE t1 (`rows` float, a int) ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
+
+select * from t1;
+drop table t1;
+SET mytile_create_allow_subset_existing_array=0;

--- a/mytile/mytile-sysvars.cc
+++ b/mytile/mytile-sysvars.cc
@@ -103,6 +103,18 @@ static MYSQL_THDVAR_BOOL(compute_table_records,
                          "compute size of table (record count) on opening",
                          NULL, NULL, false);
 
+// Running a create table normally has two modes, assisted discovery or create new
+// This option allows for a third mode, which is you can specify the list of
+// columns in the create statement and if the array already exists MariaDB will
+// just only access the columns you've specified. This is a workaround for MariaDB
+// only allowing 4096 column in total. Now if your array has more columns then
+// mariadb can handle you an use this option to select a smaller subset for
+// querying
+static MYSQL_THDVAR_BOOL(create_allow_subset_existing_array,
+                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_THDLOCAL,
+                         "Allow registering a subset of column",
+                         NULL, NULL, false);
+
 const char *log_level_names[] = {"error", "warning", "info", "debug", NullS};
 
 TYPELIB log_level_typelib = {array_elements(log_level_names) - 1,
@@ -123,6 +135,7 @@ struct st_mysql_sys_var *mytile_system_variables[] = {
     MYSQL_SYSVAR(enable_pushdown),
     MYSQL_SYSVAR(compute_table_records),
     MYSQL_SYSVAR(log_level),
+    MYSQL_SYSVAR(create_allow_subset_existing_array),
     NULL};
 
 ulonglong read_buffer_size(THD *thd) { return THDVAR(thd, read_buffer_size); }
@@ -154,6 +167,10 @@ my_bool enable_pushdown(THD *thd) { return THDVAR(thd, enable_pushdown); }
 
 my_bool compute_table_records(THD *thd) {
   return THDVAR(thd, compute_table_records);
+}
+
+my_bool create_allow_subset_existing_array(THD *thd) {
+  return THDVAR(thd, create_allow_subset_existing_array);
 }
 
 LOG_LEVEL log_level(THD *thd) { return LOG_LEVEL(THDVAR(thd, log_level)); }

--- a/mytile/mytile-sysvars.h
+++ b/mytile/mytile-sysvars.h
@@ -65,6 +65,8 @@ my_bool enable_pushdown(THD *thd);
 
 my_bool compute_table_records(THD *thd);
 
+my_bool create_allow_subset_existing_array(THD *thd);
+
 LOG_LEVEL log_level(THD *thd);
 } // namespace sysvars
 } // namespace tile


### PR DESCRIPTION
If a TileDB array has more than the 4096 max columns that MariaDB supports we want to allow the user to issues a create table statement to register a subset of the dimensions/attributes. This behavior is controlled by the new `mytile_create_allow_subset_existing_array` session parameter. The default behavior, error if issuing a create table with columns on an existing, is left intact as for most users they will not want subsetting but instead likely would be trying to create a
new array.

Example SQL usage on an array which has 5k attributes:
```
MariaDB [test]> create table test_1 engine=MyTile uri='/tmp/attributes_5k';
ERROR 1939 (HY000): Engine MyTile failed to discover table `test`.`test_1` with 'create table `test_1` (
`d0` INTEGER dimension=1 lower_bound='0' upper_bound='10000000' tile_extent='100',
`a4998` INTEGER DEFAULT -2147483648,
`a4997` INTEGER DEFAULT -2147483648,
`a4996` INTEGER DEFAULT -2147483648,
`a4991` INTEGER DEFAULT -2147483648,
`a4987` INTEGER DEFAULT -2147483648,
`a4986` INTEGER DEFAULT -2147483648,
`a4981` INTEGER DEFAULT -2147483648,
`a4980` INTEGER DEFAULT -2147483648,
`a4979` INTEGER DEFAULT -2147483648,
`a4977` IN
MariaDB [test]> set mytile_create_allow_subset_existing_array=1;
Query OK, 0 rows affected (0.000 sec)

MariaDB [test]> create table test_1 (d0 int, a0 int, a1 int, a2 int, a3 int)  engine=MyTile uri='/tmp/attributes_5k';
Query OK, 0 rows affected (0.012 sec)

MariaDB [test]> show create table test_1\G
*************************** 1. row ***************************
       Table: test_1
Create Table: CREATE TABLE `test_1` (
  `d0` int(11) DEFAULT NULL,
  `a0` int(11) DEFAULT NULL,
  `a1` int(11) DEFAULT NULL,
  `a2` int(11) DEFAULT NULL,
  `a3` int(11) DEFAULT NULL
) ENGINE=MyTile DEFAULT CHARSET=utf8 `uri`='/tmp/attributes_5k'
1 row in set (0.017 sec)

# Table is empty so no results expected but querying works
MariaDB [test]> select * from test_1;
Empty set (0.032 sec)
````