### PR TITLE
Added mariadb.sys user to the list of system users to fix Docker entrypoint

### DIFF
--- a/docker/docker-entrypoint-interactive.sh
+++ b/docker/docker-entrypoint-interactive.sh
@@ -167,7 +167,7 @@ EOSQL
     --  or products like mysql-fabric won't work
     SET @@SESSION.SQL_LOG_BIN=0;
 
-    DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
+    DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mariadb.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
     SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${MYSQL_ROOT_PASSWORD}') ;
     GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
     ${rootCreate}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -176,7 +176,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			--  or products like mysql-fabric won't work
 			SET @@SESSION.SQL_LOG_BIN=0;
 
-			DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
+			DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mariadb.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
 			SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${MYSQL_ROOT_PASSWORD}') ;
 			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 			${rootCreate}


### PR DESCRIPTION
Launching the `tiledb/tiledb-mariadb` and `tiledb/tiledb-mariadb-server` docker images currently result in an infinite loop waiting for MariaDB to initialize due to the following error: `The user specified as a definer ('mariadb.sys'@'localhost') does not exist`.

This change adds the `mariadb.sys` user to the exclusion list. More information on the MariaDB changes that caused this problem can be found in the comments of [this ticket](https://jira.mariadb.org/browse/MDEV-22542).