### PR TITLE
conditionally include plugin load add for mytile based on embedded build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,3 +126,11 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     target_include_directories(mytile PUBLIC "${EP_INSTALL_PREFIX}/include" "mytile")
     INSTALL(FILES ${TILEDB_INSTALL_LIBRARIES} DESTINATION ${INSTALL_PLUGINDIR})
 endif()
+
+# Set my.cnf values based on build flags
+if(WITH_EMBEDDED_SERVER)
+    SET(MYTILE_PLUGIN_LOAD_ADD "# plugin-load-add=ha_mytile")
+else()
+    SET(MYTILE_PLUGIN_LOAD_ADD "plugin-load-add=ha_mytile")
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mysql-test/mytile/my.cnf.in ${CMAKE_CURRENT_SOURCE_DIR}/mysql-test/mytile/my.cnf)

--- a/mysql-test/mytile/my.cnf.in
+++ b/mysql-test/mytile/my.cnf.in
@@ -2,7 +2,7 @@
 
 [server]
 plugin-maturity=experimental
-plugin-load-add=ha_mytile
+${MYTILE_PLUGIN_LOAD_ADD}
 # Enable embedded mytile
 plugin-mytile=ON
 #default-storage-engine=MyTile


### PR DESCRIPTION
adds a confugure_file step to CMakeLists which enables/disables mytile plugin loading in my.cnf depending on the value of WITH_EMBEDDED_SERVER. 