### PR TITLE
Handle datetime pushdown with Item_cache_datetime

### DIFF
--- a/mysql-test/mytile/r/datetime_pushdown.result
+++ b/mysql-test/mytile/r/datetime_pushdown.result
@@ -245,6 +245,13 @@ column1	column2
 2020-06-20 05:00:00	jun
 2020-07-20 06:00:00	jul
 2020-08-20 07:00:00	aug
+SELECT * from dt WHERE column1 between '2020-06-20 05:00:00' AND '2020-10-20 09:00:00';
+column1	column2
+2020-06-20 05:00:00	jun
+2020-07-20 06:00:00	jul
+2020-08-20 07:00:00	aug
+2020-09-20 08:00:00	sep
+2020-10-20 09:00:00	oct
 DROP TABLE dt;
 CREATE TABLE datetime_dimensions ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/2.0/datetime_dimensions';;
 EXPLAIN SELECT dt_y FROM datetime_dimensions WHERE dt_y = 2020;

--- a/mysql-test/mytile/t/datetime_pushdown.test
+++ b/mysql-test/mytile/t/datetime_pushdown.test
@@ -129,6 +129,7 @@ SELECT * from dt WHERE column1 <= '2020-10-20 09:00:00';
 SELECT * from dt WHERE column1 > '2020-01-01 00:00:00' AND column1 <= '2020-05-20 04:00:00';
 SELECT * from dt WHERE column1 >= '2020-06-20 05:00:00' AND column1 <= '2020-10-20 09:00:00';
 SELECT * from dt WHERE column1 > '2020-02-20 01:00:00' AND column1 < '2020-09-20 08:00:00';
+SELECT * from dt WHERE column1 between '2020-06-20 05:00:00' AND '2020-10-20 09:00:00';
 DROP TABLE dt;
 
 #echo external array - datetime dimensions

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -277,6 +277,13 @@ public:
   const COND *cond_push_func(const Item_func *func_item);
 
   /**
+   * Handle datetiem function pushdowns
+   * @param func_item
+   * @return
+   */
+  const COND *cond_push_func_datetime(const Item_func *func_item);
+
+  /**
   Push condition down to the table handler.
 
   @param  cond   Condition to be pushed. The condition tree must not be

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -66,6 +66,13 @@ int set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,
                                Item_result cmp_type,
                                std::shared_ptr<tile::range> &range,
                                tiledb_datatype_t datatype);
+
+int set_range_from_item_datetime(THD *thd, Item_cache_datetime *lower_const,
+                                 Item_cache_datetime *upper_const,
+                                 Item_result cmp_type,
+                                 std::shared_ptr<tile::range> &range,
+                                 tiledb_datatype_t datatype);
+
 /**
  * Take a range, and will set the lower/upper bound as appropriate if it is
  * missing and takes into account the mariadb operations.


### PR DESCRIPTION
If the condition being pushed is a datetime we need to handle and check for Item_cache_datetime types to avoid a segfault when we incorrectly casted the Items to Item_basic_constant.