### PR TITLE
Fix handling of string key comparison and ranges

### DIFF
--- a/mysql-test/mytile/r/string_dim.result
+++ b/mysql-test/mytile/r/string_dim.result
@@ -11,3 +11,24 @@ dddd	1
 jfk	5
 SET mytile_delete_arrays=0;
 DROP TABLE string_dim;
+# VARCHAR Dimension
+CREATE TABLE t1 (
+dim1 varchar(255) dimension=1,
+dim2 varchar(255) dimension=1,
+attr1 integer,
+PRIMARY KEY(dim1, dim2)
+) ENGINE=mytile;
+INSERT INTO t1 VALUES ("a", "b", 1);
+INSERT INTO t1 VALUES ("a", "c", 2);
+INSERT INTO t1 VALUES ("a", "d", 3);
+INSERT INTO t1 VALUES ("aa", "b", 4);
+select * FROM t1;
+dim1	dim2	attr1
+a	b	1
+a	c	2
+a	d	3
+aa	b	4
+select * FROM t1 WHERE dim1 = "aa";
+dim1	dim2	attr1
+aa	b	4
+DROP TABLE t1;

--- a/mysql-test/mytile/t/string_dim.test
+++ b/mysql-test/mytile/t/string_dim.test
@@ -8,3 +8,18 @@
 SELECT * FROM string_dim;
 SET mytile_delete_arrays=0;
 DROP TABLE string_dim;
+
+--echo # VARCHAR Dimension
+CREATE TABLE t1 (
+  dim1 varchar(255) dimension=1,
+  dim2 varchar(255) dimension=1,
+  attr1 integer,
+  PRIMARY KEY(dim1, dim2)
+) ENGINE=mytile;
+INSERT INTO t1 VALUES ("a", "b", 1);
+INSERT INTO t1 VALUES ("a", "c", 2);
+INSERT INTO t1 VALUES ("a", "d", 3);
+INSERT INTO t1 VALUES ("aa", "b", 4);
+select * FROM t1;
+select * FROM t1 WHERE dim1 = "aa";
+DROP TABLE t1;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -2325,7 +2325,7 @@ int8_t tile::mytile::compare_key_to_dims(const uchar *key, uint key_len,
       if (dim_buffer == nullptr || dim_buffer->name != dimension.name()) {
         continue;
       } else { // buffer for dimension was found
-        uint64_t dim_comparison =
+        uint8_t dim_comparison =
             compare_key_to_dim(dim_idx, key + key_position,
                                key_part_info->length, index, dim_buffer);
         key_position += key_part_info->length;
@@ -2427,6 +2427,12 @@ int8_t tile::mytile::compare_key_to_dim(const uint64_t dim_idx,
       end_position = buf->offset_buffer[index + 1];
     }
     size_t size = end_position - start_position;
+
+    // If the key size is zero, this can happen when we are doing partial key
+    // matches For strings a size of 0 means anything should be considered a
+    // match so we return 0
+    if (char_length == 0)
+      return 0;
 
     void *buff = (static_cast<char *>(buf->buffer) + start_position);
 

--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -956,6 +956,11 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
     case tiledb_datatype_t::TILEDB_STRING_ASCII: {
       const uint16_t char_length =
           *reinterpret_cast<const uint16_t *>(key + key_offset);
+      // If there is no string set the range to nullptr
+      if (char_length == 0) {
+        ranges[dim_idx] = nullptr;
+        break;
+      }
       key_offset += sizeof(uint16_t);
       ranges[dim_idx] = build_range_from_key<char>(
           key + key_offset, length, find_flag, start_key, last_key_part,


### PR DESCRIPTION
This fixes two issues, the first being that we incorrectly were copying the key for pushdown onto the TileDB range. We were accidentally only considering the first character instead of all characters.

Second we were not handling partial key matches. For strings a partial key comparison might include zero length keys, which should be considered for any match. This adjusts to capture the comparison of zero length string.