### PR TITLE
Handle var length dims in compute_table_records

### DIFF
--- a/mysql-test/mytile/r/string_dim.result
+++ b/mysql-test/mytile/r/string_dim.result
@@ -9,6 +9,16 @@ bb	2
 cc	3
 dddd	1
 jfk	5
+FLUSH TABLES;
+SET mytile_compute_table_records=1;
+SELECT * FROM string_dim;
+d	a
+aa	4
+bb	2
+cc	3
+dddd	1
+jfk	5
+SET mytile_compute_table_records=0;
 SET mytile_delete_arrays=0;
 DROP TABLE string_dim;
 # VARCHAR Dimension

--- a/mysql-test/mytile/t/string_dim.test
+++ b/mysql-test/mytile/t/string_dim.test
@@ -6,6 +6,10 @@
 --eval CREATE TABLE string_dim ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/2.0/string_dim';
 
 SELECT * FROM string_dim;
+FLUSH TABLES;
+SET mytile_compute_table_records=1;
+SELECT * FROM string_dim;
+SET mytile_compute_table_records=0;
 SET mytile_delete_arrays=0;
 DROP TABLE string_dim;
 


### PR DESCRIPTION
In handling the option for computing the number of records in an array, we were missing handling string based dimensions. This adds a check to handle this case.