### PR TITLE
ref for position can't be reset with MRR

### DIFF
--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -222,14 +222,6 @@ public:
   std::vector<uint8_t> get_coords_as_byte_vector(uint64_t index);
 
   /**
-   * Realloc the ref based on current size of data
-   * This is needed for string dims
-   * @param size
-   * @return
-   */
-  int realloc_ref_based_size(uint64_t size);
-
-  /**
    * Write row
    * @param buf
    * @return


### PR DESCRIPTION
For variable length dimensions we were resetting the `ref_length` and reallocating `ref` when the handler called for `position()` based on the string size of the current coordinates. This doesn't work for MRR cases though because the address of `ref` is taken before `position()` is called.

The quick fix is we'll always set the `ref_length` to the maximum allowed size of a row. This means we'll allocate an extra 65KB, but in the grand scheme this is insignificant for most usages and we only generally store a small amount of positions.