### PR TITLE
Converting MariaDB datatime should always use UTC

### DIFF
--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -449,8 +449,7 @@ int64_t tile::MysqlTimeToTileDBTimeVal(THD *thd, const MYSQL_TIME &mysql_time,
       // else we have a date and time which must take tz into account
     } else {
       uint32_t not_used;
-      seconds =
-          thd->variables.time_zone->TIME_to_gmt_sec(&mysql_time, &not_used);
+      seconds = my_tz_OFFSET0->TIME_to_gmt_sec(&mysql_time, &not_used);
     }
     uint64_t microseconds = mysql_time.second_part;
 


### PR DESCRIPTION
Previously we were using system timezone to convert to UTC, this meant queries were off compared to what the user expected.

No unit test was added because in the test env (azure pipelines) we don't have timezones loaded so everything is always UTC. I didn't think it was worth the effort right now to set that up.