### PR TITLE
Handle datetime in MRR key merging

### DIFF
--- a/mysql-test/mytile/r/mrr_datetime_dimensions.result
+++ b/mysql-test/mytile/r/mrr_datetime_dimensions.result
@@ -1,0 +1,58 @@
+#
+# The purpose of this test is to validate MyTile datetime conditions with MRR
+#
+CREATE TABLE dt (
+column1 datetime(0) dimension=1 tile_extent="10",
+column2 int dimension=1 tile_extent="10",
+column3 VARCHAR(255)
+) ENGINE=mytile;
+INSERT INTO dt VALUES ('2020-01-01 00:00:00',1,'jan');
+INSERT INTO dt VALUES ('2020-02-20 01:00:00',2, 'feb');
+INSERT INTO dt VALUES ('2020-03-20 02:00:00',3,'mar');
+INSERT INTO dt VALUES ('2020-04-20 02:00:00',4,'apr');
+INSERT INTO dt VALUES ('2020-05-20 04:00:00',5,'may');
+INSERT INTO dt VALUES ('2020-06-20 05:00:00',6,'jun');
+INSERT INTO dt VALUES ('2020-07-20 06:00:00',7,'jul');
+INSERT INTO dt VALUES ('2020-08-20 07:00:00',8,'aug');
+INSERT INTO dt VALUES ('2020-09-20 08:00:00',9,'sep');
+INSERT INTO dt VALUES ('2020-10-20 09:00:00',10,'oct');
+# Batch Key Access (Sorted) Join
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=6;
+SELECT * from dt WHERE column1 > '2020-01-01 00:00:00' AND column2 = 2;
+column1	column2	column3
+2020-02-20 01:00:00	2	feb
+SELECT * from dt WHERE column1 < '2020-10-20 09:00:00' AND column2 = 2;
+column1	column2	column3
+2020-02-20 01:00:00	2	feb
+SELECT * from dt WHERE column1 >= '2020-01-01 00:00:00' AND column2 = 2;
+column1	column2	column3
+2020-02-20 01:00:00	2	feb
+SELECT * from dt WHERE column1 <= '2020-10-20 09:00:00' AND column2 = 2;
+column1	column2	column3
+2020-02-20 01:00:00	2	feb
+SELECT * from dt WHERE column1 > '2020-01-01 00:00:00' AND column1 <= '2020-05-20 04:00:00' AND column2 = 2;
+column1	column2	column3
+2020-02-20 01:00:00	2	feb
+SELECT * from dt WHERE column1 >= '2020-06-20 05:00:00' AND column1 <= '2020-10-20 09:00:00' AND column2 = 7;
+column1	column2	column3
+2020-07-20 06:00:00	7	jul
+SELECT * from dt WHERE column1 > '2020-02-20 01:00:00' AND column1 < '2020-09-20 08:00:00' AND column2 = 5;
+column1	column2	column3
+2020-05-20 04:00:00	5	may
+SELECT * from dt WHERE column1 between '2020-06-20 05:00:00' AND '2020-10-20 09:00:00' AND column2 = 7;
+column1	column2	column3
+2020-07-20 06:00:00	7	jul
+SELECT * from dt inner join dt dt2 USING(column1, column2);
+column1	column2	column3	column3
+2020-01-01 00:00:00	1	jan	jan
+2020-02-20 01:00:00	2	feb	feb
+2020-03-20 02:00:00	3	mar	mar
+2020-04-20 02:00:00	4	apr	apr
+2020-05-20 04:00:00	5	may	may
+2020-06-20 05:00:00	6	jun	jun
+2020-07-20 06:00:00	7	jul	jul
+2020-08-20 07:00:00	8	aug	aug
+2020-09-20 08:00:00	9	sep	sep
+2020-10-20 09:00:00	10	oct	oct
+DROP TABLE dt;

--- a/mysql-test/mytile/t/mrr_datetime_dimensions.test
+++ b/mysql-test/mytile/t/mrr_datetime_dimensions.test
@@ -1,0 +1,37 @@
+--echo #
+--echo # The purpose of this test is to validate MyTile datetime conditions with MRR
+--echo #
+
+#echo ranges
+CREATE TABLE dt (
+  column1 datetime(0) dimension=1 tile_extent="10",
+  column2 int dimension=1 tile_extent="10",
+  column3 VARCHAR(255)
+) ENGINE=mytile;
+INSERT INTO dt VALUES ('2020-01-01 00:00:00',1,'jan');
+INSERT INTO dt VALUES ('2020-02-20 01:00:00',2, 'feb');
+INSERT INTO dt VALUES ('2020-03-20 02:00:00',3,'mar');
+INSERT INTO dt VALUES ('2020-04-20 02:00:00',4,'apr');
+INSERT INTO dt VALUES ('2020-05-20 04:00:00',5,'may');
+INSERT INTO dt VALUES ('2020-06-20 05:00:00',6,'jun');
+INSERT INTO dt VALUES ('2020-07-20 06:00:00',7,'jul');
+INSERT INTO dt VALUES ('2020-08-20 07:00:00',8,'aug');
+INSERT INTO dt VALUES ('2020-09-20 08:00:00',9,'sep');
+INSERT INTO dt VALUES ('2020-10-20 09:00:00',10,'oct');
+
+--echo # Batch Key Access (Sorted) Join
+set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
+set join_cache_level=6;
+
+SELECT * from dt WHERE column1 > '2020-01-01 00:00:00' AND column2 = 2;
+SELECT * from dt WHERE column1 < '2020-10-20 09:00:00' AND column2 = 2;
+
+SELECT * from dt WHERE column1 >= '2020-01-01 00:00:00' AND column2 = 2;
+SELECT * from dt WHERE column1 <= '2020-10-20 09:00:00' AND column2 = 2;
+
+SELECT * from dt WHERE column1 > '2020-01-01 00:00:00' AND column1 <= '2020-05-20 04:00:00' AND column2 = 2;
+SELECT * from dt WHERE column1 >= '2020-06-20 05:00:00' AND column1 <= '2020-10-20 09:00:00' AND column2 = 7;
+SELECT * from dt WHERE column1 > '2020-02-20 01:00:00' AND column1 < '2020-09-20 08:00:00' AND column2 = 5;
+SELECT * from dt WHERE column1 between '2020-06-20 05:00:00' AND '2020-10-20 09:00:00' AND column2 = 7;
+SELECT * from dt inner join dt dt2 USING(column1, column2);
+DROP TABLE dt;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -2726,6 +2726,15 @@ int tile::mytile::build_mrr_ranges() {
         uint64_t key_len = 0;
         bool last_key_part = false;
         tiledb_datatype_t datatype = dims[i].type();
+        Field *field;
+        for (uint64_t fi = 0; fi < table->s->fields; fi++) {
+          Field *f = table->s->field[fi];
+          if (std::string(f->field_name.str, f->field_name.length) ==
+              dims[i].name()) {
+            field = f;
+            break;
+          }
+        }
 
         auto &range = tmp_ranges[i];
         if (datatype == TILEDB_STRING_ASCII) {
@@ -2750,9 +2759,9 @@ int tile::mytile::build_mrr_ranges() {
           last_key_part = true;
 
         range->datatype = datatype;
-        update_range_from_key_for_super_range(range, mrr_cur_range.start_key,
-                                              key_offset, true /* start_key */,
-                                              last_key_part, datatype);
+        update_range_from_key_for_super_range(
+            range, mrr_cur_range.start_key, key_offset, true /* start_key */,
+            last_key_part, datatype, ha_thd(), field);
         key_offset += key_len;
       }
     }
@@ -2770,6 +2779,16 @@ int tile::mytile::build_mrr_ranges() {
         uint64_t key_len = 0;
         bool last_key_part = false;
         tiledb_datatype_t datatype = dims[i].type();
+        Field *field;
+        for (uint64_t fi = 0; fi < table->s->fields; fi++) {
+          Field *f = table->s->field[fi];
+          if (std::string(f->field_name.str, f->field_name.length) ==
+              dims[i].name()) {
+            field = f;
+            break;
+          }
+        }
+
         auto &range = tmp_ranges[i];
 
         if (datatype == TILEDB_STRING_ASCII) {
@@ -2791,9 +2810,9 @@ int tile::mytile::build_mrr_ranges() {
           last_key_part = true;
 
         range->datatype = datatype;
-        update_range_from_key_for_super_range(range, mrr_cur_range.end_key,
-                                              key_offset, false /* start_key */,
-                                              last_key_part, datatype);
+        update_range_from_key_for_super_range(
+            range, mrr_cur_range.end_key, key_offset, false /* start_key */,
+            last_key_part, datatype, ha_thd(), field);
         key_offset += key_len;
       }
     }

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -652,7 +652,8 @@ void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
                                            key_range key, uint64_t key_offset,
                                            const bool start_key,
                                            const bool last_key_part,
-                                           tiledb_datatype_t datatype);
+                                           tiledb_datatype_t datatype, THD *thd,
+                                           Field *field);
 
 /**
  * See non-templated version for description

--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -449,8 +449,7 @@ int64_t tile::MysqlTimeToTileDBTimeVal(THD *thd, const MYSQL_TIME &mysql_time,
       // else we have a date and time which must take tz into account
     } else {
       uint32_t not_used;
-      seconds =
-          thd->variables.time_zone->TIME_to_gmt_sec(&mysql_time, &not_used);
+      seconds = my_tz_OFFSET0->TIME_to_gmt_sec(&mysql_time, &not_used);
     }
     uint64_t microseconds = mysql_time.second_part;
 


### PR DESCRIPTION
Handle datetime in MRR key merging, this fixes an issue with a customer query where due to the size the condition was being applied as MRR.