### PR TITLE
Updated docker-entrypoint-interacitve startup query ot use mysql.global_priv table

### DIFF
--- a/docker/docker-entrypoint-interactive.sh
+++ b/docker/docker-entrypoint-interactive.sh
@@ -219,7 +219,7 @@ fi
 mysqld > /var/log/mysql/all.log 2>&1 &
 
 printf "Waiting for mariadb to initialize.."
-until mysql -u root -e "select * from mysql.user;" &> /dev/null ;
+until mysql -u root -e "select * from mysql.global_priv;" &> /dev/null ;
 do
   printf ".";
   sleep 1;


### PR DESCRIPTION
My attempt in #134 to fix the infinite waiting when launching the interactive Docker image, unfortunately, didn't resolve the problem. The current `docker-entrypoint-interactive.sh` entry point used in some of the Dockerfiles still suffers from infinite waiting because of: `The user specified as a definer ('mariadb.sys'@'localhost') does not exist`

The following change now addresses the issue, and upon running the container a user is dropped inside a MariaDB shell. The solution was to query the `mysql.global_priv` table instead of `mysql.user` per [the following clafirication](https://jira.mariadb.org/browse/MDEV-22909?focusedCommentId=157925&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-157925) that MariaDB in 10.4 uses `mysql.global_priv` and older versions use `mysql.user` to store user information.

```
docker run -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -it --rm -v ~/workspace/TileDB-Py/examples/strDimTest:/data/local_array sgloutnikov/tiledb-mariadb:0.7.3
Waiting for mariadb to initialize....
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 9
Server version: 10.4.17-MariaDB MariaDB Server

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [test]>
```