### PR TITLE
Increase default row count to 100000

### DIFF
--- a/mysql-test/mytile/r/datetime_pushdown.result
+++ b/mysql-test/mytile/r/datetime_pushdown.result
@@ -15,13 +15,13 @@ column1	column2
 2020-10-20 02:00:00.000000	dmFsdWU
 EXPLAIN SELECT column1, column2 FROM dt WHERE column1 = '2020-10-20 02:00:00.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	dt	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	dt	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM dt WHERE column1 = '2020-10-20 02:00:00.000000';
 column1	column2
 2020-10-20 02:00:00.000000	dmFsdWU
 EXPLAIN SELECT column2 FROM dt WHERE column1 IN ('2020-10-20 00:00:00.000000','2020-10-20 02:00:00.000000') ORDER BY column1 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	dt	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	dt	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
 SELECT column2 FROM dt WHERE column1 IN ('2020-10-20 00:00:00.000000','2020-10-20 02:00:00.000000') ORDER BY column1 asc;
 column2
 aHR0cHM6Ly9naXRodWIuY29tL1NoZWxudXR0Mi9jcnVuY2g=
@@ -44,43 +44,43 @@ column1	column2
 2020-10-22 02:00:00.789	third
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-20 00:00:00.123';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-20 00:00:00.123';
 column1	column2
 2020-10-20 00:00:00.123	first
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-20 00:00:00.1230';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-20 00:00:00.1230';
 column1	column2
 2020-10-20 00:00:00.123	first
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-21 01:00:00.456';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-21 01:00:00.456';
 column1	column2
 2020-10-21 01:00:00.456	second
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-21 01:00:00.45600';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-21 01:00:00.45600';
 column1	column2
 2020-10-21 01:00:00.456	second
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-22 02:00:00.789';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-22 02:00:00.789';
 column1	column2
 2020-10-22 02:00:00.789	third
 EXPLAIN SELECT column1, column2 FROM ts WHERE column1 = '2020-10-22 02:00:00.789000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT column1, column2 FROM ts WHERE column1 = '2020-10-22 02:00:00.789000';
 column1	column2
 2020-10-22 02:00:00.789	third
 EXPLAIN SELECT column2 FROM ts WHERE column1 IN ('2020-10-20 00:00:00.123', '2020-10-22 02:00:00.789') ORDER BY column1 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using filesort
+1	SIMPLE	ts	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using filesort
 SELECT column2 FROM ts WHERE column1 IN ('2020-10-20 00:00:00.123', '2020-10-22 02:00:00.789') ORDER BY column1 asc;
 column2
 first
@@ -100,25 +100,25 @@ column1	column2
 2020-10-23	2020
 EXPLAIN SELECT * FROM d WHERE column1 = '1970-12-31';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM d WHERE column1 = '1970-12-31';
 column1	column2
 1970-12-31	1970
 EXPLAIN SELECT * FROM d WHERE column1 = '2000-06-11';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM d WHERE column1 = '2000-06-11';
 column1	column2
 2000-06-11	2000
 EXPLAIN SELECT * FROM d WHERE column1 = '2020-10-23';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM d WHERE column1 = '2020-10-23';
 column1	column2
 2020-10-23	2020
 EXPLAIN SELECT * from d WHERE column1 IN ('1970-12-31', '2000-06-11', '2020-10-23');
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	d	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * from d WHERE column1 IN ('1970-12-31', '2000-06-11', '2020-10-23');
 column1	column2
 1970-12-31	1970
@@ -139,25 +139,25 @@ column1	column2
 2050	2050
 EXPLAIN SELECT * FROM y WHERE column1 = 1970;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM y WHERE column1 = 1970;
 column1	column2
 1970	1970
 EXPLAIN SELECT * FROM y WHERE column1 = 2000;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM y WHERE column1 = 2000;
 column1	column2
 2000	2000
 EXPLAIN SELECT * FROM y WHERE column1 = 2050;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * FROM y WHERE column1 = 2050;
 column1	column2
 2050	2050
 EXPLAIN SELECT * from y WHERE column1 IN (1970, 2000, 2050);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	y	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 SELECT * from y WHERE column1 IN (1970, 2000, 2050);
 column1	column2
 1970	1970
@@ -262,73 +262,73 @@ dt_y
 2020
 EXPLAIN SELECT dt_m FROM datetime_dimensions WHERE dt_m = '2029-12-17 00:00:00.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_m FROM datetime_dimensions WHERE dt_m = '2029-12-17 00:00:00.000000';
 dt_m
 2029-12-17 00:00:00.000000
 EXPLAIN SELECT dt_w FROM datetime_dimensions WHERE dt_w = '2017-11-30 00:00:00.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_w FROM datetime_dimensions WHERE dt_w = '2017-11-30 00:00:00.000000';
 dt_w
 2017-11-30 00:00:00.000000
 EXPLAIN SELECT dt_d FROM datetime_dimensions WHERE dt_d = '2020-10-25';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_d FROM datetime_dimensions WHERE dt_d = '2020-10-25';
 dt_d
 2020-10-25
 EXPLAIN SELECT dt_hr FROM datetime_dimensions WHERE dt_hr = '2020-10-25 13:00:00.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_hr FROM datetime_dimensions WHERE dt_hr = '2020-10-25 13:00:00.000000';
 dt_hr
 2020-10-25 13:00:00.000000
 EXPLAIN SELECT dt_min FROM datetime_dimensions WHERE dt_min = '2020-10-25 13:07:00.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_min FROM datetime_dimensions WHERE dt_min = '2020-10-25 13:07:00.000000';
 dt_min
 2020-10-25 13:07:00.000000
 EXPLAIN SELECT dt_s FROM datetime_dimensions WHERE dt_s = '2020-10-25 13:07:18.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_s FROM datetime_dimensions WHERE dt_s = '2020-10-25 13:07:18.000000';
 dt_s
 2020-10-25 13:07:18.000000
 EXPLAIN SELECT dt_ms FROM datetime_dimensions WHERE dt_ms = '2020-10-25 13:07:18.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_ms FROM datetime_dimensions WHERE dt_ms = '2020-10-25 13:07:18.000000';
 dt_ms
 2020-10-25 13:07:18.000000
 EXPLAIN SELECT dt_us FROM datetime_dimensions WHERE dt_us = '2020-10-25 13:07:18.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_us FROM datetime_dimensions WHERE dt_us = '2020-10-25 13:07:18.000000';
 dt_us
 2020-10-25 13:07:18.000000
 EXPLAIN SELECT dt_ns FROM datetime_dimensions WHERE dt_ns = '2020-10-25 13:07:18.000000';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_ns FROM datetime_dimensions WHERE dt_ns = '2020-10-25 13:07:18.000000';
 dt_ns
 2020-10-25 13:07:18.000000
 EXPLAIN SELECT dt_ps FROM datetime_dimensions WHERE dt_ps = '1970-01-01 00:00:00.012300';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_ps FROM datetime_dimensions WHERE dt_ps = '1970-01-01 00:00:00.012300';
 dt_ps
 1970-01-01 00:00:00.012300
 EXPLAIN SELECT dt_fs FROM datetime_dimensions WHERE dt_fs = '1970-01-01 00:00:00.012300';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_fs FROM datetime_dimensions WHERE dt_fs = '1970-01-01 00:00:00.012300';
 dt_fs
 1970-01-01 00:00:00.012300
 EXPLAIN SELECT dt_as FROM datetime_dimensions WHERE dt_as = '1970-01-01 00:00:00.012300';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	datetime_dimensions	index	NULL	PRIMARY	81	NULL	100000	Using where with pushed condition; Using index
 SELECT dt_as FROM datetime_dimensions WHERE dt_as = '1970-01-01 00:00:00.012300';
 dt_as
 1970-01-01 00:00:00.012300

--- a/mysql-test/mytile/r/estimated_table_records.result
+++ b/mysql-test/mytile/r/estimated_table_records.result
@@ -4,7 +4,7 @@
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 explain select * from `quickstart_dense` ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	100000	Using filesort
 set mytile_compute_table_records=1;
 FLUSH TABLES;
 explain select * from `quickstart_dense` ORDER BY `rows` asc, cols asc;

--- a/mysql-test/mytile/r/join.result
+++ b/mysql-test/mytile/r/join.result
@@ -5,7 +5,7 @@ CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_
 # Block Nested Loop Join Explain with Index
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -32,8 +32,8 @@ CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_
 # Block Nested Loop Join Explain
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using temporary; Using filesort
-1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	2	Using where; Using join buffer (flat, BNL join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using temporary; Using filesort
+1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	100000	Using where; Using join buffer (flat, BNL join)
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
 1	1	1	1

--- a/mysql-test/mytile/r/mrr.result
+++ b/mysql-test/mytile/r/mrr.result
@@ -7,14 +7,14 @@ CREATE TABLE bank ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/2.0/b
 # Block Nested Loop Join Explain
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	
 # Batch Key Access (Sorted) Join
 set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=6;
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join); Key-ordered scan
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -39,7 +39,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join)
 select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -51,7 +51,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=8;
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKAH join); Key-ordered scan
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -76,7 +76,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=8;
 explain select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKAH join)
 select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -87,7 +87,7 @@ rows	cols	a	a
 set optimizer_switch='optimize_join_buffer_size=off,mrr=off,mrr_sort_keys=off';
 explain select id, job from `bank` where id between 1 and 10 AND job in ('retired', 'management');
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	bank	index	PRIMARY	PRIMARY	265	NULL	2	Using where with pushed condition; Using index
+1	SIMPLE	bank	range	PRIMARY	PRIMARY	265	NULL	1	Using where with pushed condition; Using index
 select id, job from `bank` where id between 1 and 10 AND job in ('retired', 'management');
 id	job
 5	management

--- a/mysql-test/mytile/r/mrr_heterogeneus_dimensions.result
+++ b/mysql-test/mytile/r/mrr_heterogeneus_dimensions.result
@@ -14,15 +14,15 @@ INSERT INTO tmhd (d1, d2, a) VALUES (1.5, 5, 5);
 INSERT INTO tmhd (d1, d2, a) VALUES (1.6, 6, 6);
 explain select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using temporary; Using filesort
-1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	2	Using where; Using join buffer (flat, BNL join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using temporary; Using filesort
+1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	100000	Using where; Using join buffer (flat, BNL join)
 # Batch Key Access (Sorted) Join
 set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=6;
 explain select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	1	1	1
@@ -36,8 +36,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	1	1	1
@@ -51,8 +51,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=8;
 explain select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	1	1	1
@@ -66,8 +66,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=8;
 explain select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	14	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	1	1	1

--- a/mysql-test/mytile/r/mrr_incomplete_queries.result
+++ b/mysql-test/mytile/r/mrr_incomplete_queries.result
@@ -7,14 +7,14 @@ CREATE TABLE quickstart_sparse ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb
 # Block Nested Loop Join Explain
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	
 # Batch Key Access (Sorted) Join
 set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=6;
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join); Key-ordered scan
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -39,7 +39,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join)
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -64,7 +64,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=8;
 explain select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKAH join); Key-ordered scan
 select * from `quickstart_dense` a JOIN `quickstart_dense` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -89,7 +89,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKA join)
 select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a
@@ -102,7 +102,7 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=8;
 explain select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	2	Using temporary; Using filesort
+1	SIMPLE	a	ALL	PRIMARY	NULL	NULL	NULL	100000	Using temporary; Using filesort
 1	SIMPLE	b	eq_ref	PRIMARY	PRIMARY	8	test.a.rows,test.a.cols	1	Using join buffer (flat, BKAH join)
 select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `cols`) ORDER BY `rows` asc, cols asc;
 rows	cols	a	a

--- a/mysql-test/mytile/r/mrr_string_dim.result
+++ b/mysql-test/mytile/r/mrr_string_dim.result
@@ -14,15 +14,15 @@ INSERT INTO tmhds (d1, d2, a) VALUES (1.5, "e", 5);
 INSERT INTO tmhds (d1, d2, a) VALUES (1.6, "f", 6);
 explain select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using temporary; Using filesort
-1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	2	Using where; Using join buffer (flat, BNL join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using temporary; Using filesort
+1	SIMPLE	b	ALL	NULL	NULL	NULL	NULL	100000	Using where; Using join buffer (flat, BNL join)
 # Batch Key Access (Sorted) Join
 set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=6;
 explain select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	a	1	1
@@ -36,8 +36,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	a	1	1
@@ -51,8 +51,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=8;
 explain select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	a	1	1
@@ -66,8 +66,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=8;
 explain select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	263	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds` a JOIN `tmhds` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 1.1	a	1	1
@@ -90,15 +90,15 @@ INSERT INTO tmhds2 (d1, d2, a) VALUES ('2020-05-01 00:00:00', "may", 5);
 INSERT INTO tmhds2 (d1, d2, a) VALUES ('2020-06-01 00:00:00', "jun", 6);
 explain select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 # Batch Key Access (Sorted) Join
 set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=6;
 explain select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 2020-01-01	jan	1	1
@@ -112,8 +112,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=6;
 explain select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 2020-01-01	jan	1	1
@@ -127,8 +127,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=on';
 set join_cache_level=8;
 explain select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 2020-01-01	jan	1	1
@@ -142,8 +142,8 @@ set optimizer_switch='optimize_join_buffer_size=off,mrr=on,mrr_sort_keys=off';
 set join_cache_level=8;
 explain select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition; Using temporary; Using filesort
-1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	2	Using where; Using join buffer (flat, BNLH join)
+1	SIMPLE	a	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition; Using temporary; Using filesort
+1	SIMPLE	b	hash_ALL	NULL	#hash#$hj	262	test.a.d1,test.a.d2	100000	Using where; Using join buffer (flat, BNLH join)
 select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc;
 d1	d2	a	a
 2020-01-01	jan	1	1

--- a/mysql-test/mytile/r/primary_key.result
+++ b/mysql-test/mytile/r/primary_key.result
@@ -29,7 +29,7 @@ quickstart_dense	CREATE TABLE `quickstart_dense` (
 ) ENGINE=MyTile DEFAULT CHARSET=latin1 `uri`='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense' `array_type`='DENSE' `cell_order`=ROW_MAJOR `tile_order`=ROW_MAJOR `coordinate_filters`='ZSTD=-1' `offset_filters`='ZSTD=-1'
 explain SELECT * FROM quickstart_dense WHERE `rows` = 1 AND `cols` = 1 ORDER BY `rows`, `cols`;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	2	Using where with pushed condition
+1	SIMPLE	quickstart_dense	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
 DROP TABLE `quickstart_dense`;
 set mytile_delete_arrays=1;
 SET mytile_dimensions_are_keys=1;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -622,7 +622,9 @@ private:
   bool mrr_query = false;
 
   // Upper bound for records, used for table stats by optimized
-  uint64_t records_upper_bound = 2;
+  // We default to 100000 so that if we don't compute it, MariaDB still avoid
+  // optimizations for small tables
+  uint64_t records_upper_bound = 100000;
 
   /**
    * Helper to setup writes

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -8,7 +8,7 @@ mkdir tmp
 shopt -s extglob
 mv !(tmp) tmp # Move everything but tmp
 # Download mariadb using git, this has a habit of failing so let's do it first
-git clone https://github.com/MariaDB/server.git -b ${MARIADB_VERSION} ${MARIADB_VERSION}
+git clone --recurse-submodules https://github.com/MariaDB/server.git -b ${MARIADB_VERSION} ${MARIADB_VERSION}
 
 # Install TileDB using 2.0 release
 if [[ -z ${SUPERBUILD+x} || "${SUPERBUILD}" == "OFF" ]]; then
@@ -37,8 +37,10 @@ else # set superbuild flags
 fi
 
 mv tmp ${MARIADB_VERSION}/storage/mytile \
-&& cd ${MARIADB_VERSION} \
-&& mkdir builddir \
+&& cd ${MARIADB_VERSION}
+# Cherry-pick cmake 3.20 fix
+git cherry-pick 4e825b0e8ae07e1e847cbbc3c5b7203ae5b96a89
+mkdir builddir \
 && cd builddir \
 && cmake -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Debug -SWITH_DEBUG=1 .. \
 && make -j$(nproc) \


### PR DESCRIPTION
Computing the actual row count is optional as it can be a costly operation. Instead we have a hard coded value which MariaDB uses to make determination about the query plan. The previous value of 2, was too low and causing poor query performance as MariaDB often attempted a linear scan instead of using the "indexes" to pushdown the ranges.

The previous value of 2 was left over from initial development and this was suppose to have been increased along with the `records_in_range` value.