### PR TITLE
Add support for TileDB Time Datatypes and TileDB 2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,15 +50,15 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
     include(ExternalProject)
 
     SET(TILEDB_VERSION_MAJOR "2")
-    SET(TILEDB_VERSION_MINOR "2")
-    SET(TILEDB_VERSION_PATCH "9")
+    SET(TILEDB_VERSION_MINOR "3")
+    SET(TILEDB_VERSION_PATCH "0")
     SET(TILEDB_VERSION "${TILEDB_VERSION_MAJOR}.${TILEDB_VERSION_MINOR}.${TILEDB_VERSION_PATCH}")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb
             PREFIX "externals"
             URL "https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.zip"
-            URL_HASH SHA1=fc5eb0b3dda507e96d9f0196ee187f9304352d16
+            URL_HASH SHA1=eafcc0dc8d9608565ae2f40fd423c570de1f2e54
             DOWNLOAD_NAME "tiledb.zip"
             CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.2.8"
+ARG TILEDB_VERSION="2.3.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-R
+++ b/docker/Dockerfile-R
@@ -72,7 +72,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.2.8"
+ARG TILEDB_VERSION="2.3.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y \
 
 ENV MTR_MEM /tmp
 
-ARG TILEDB_VERSION="2.2.8"
+ARG TILEDB_VERSION="2.3.0"
 
 WORKDIR /tmp
 

--- a/docker/Dockerfile-min
+++ b/docker/Dockerfile-min
@@ -55,7 +55,7 @@ WORKDIR /tmp
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.2.8"
+ARG TILEDB_VERSION="2.3.0"
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 # Set git config so superbuild of tiledb can cherry-pick capnp fix

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -56,7 +56,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.2.8"
+ARG TILEDB_VERSION="2.3.0"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -2461,7 +2461,16 @@ int8_t tile::mytile::compare_key_to_dim(const uint64_t dim_idx,
   case TILEDB_DATETIME_NS:
   case TILEDB_DATETIME_PS:
   case TILEDB_DATETIME_FS:
-  case TILEDB_DATETIME_AS: {
+  case TILEDB_DATETIME_AS:
+  case TILEDB_TIME_HR:
+  case TILEDB_TIME_MIN:
+  case TILEDB_TIME_SEC:
+  case TILEDB_TIME_MS:
+  case TILEDB_TIME_US:
+  case TILEDB_TIME_NS:
+  case TILEDB_TIME_PS:
+  case TILEDB_TIME_FS:
+  case TILEDB_TIME_AS: {
     MYSQL_TIME mysql_time;
     Field *field = table->field[dim_idx];
 

--- a/mytile/mytile-metadata.h
+++ b/mytile/mytile-metadata.h
@@ -103,6 +103,17 @@ std::string build_metadata_datetime_value_string(THD *thd, const void *data,
                                                  tiledb_datatype_t type);
 
 /**
+ * Convert times to csv list of times
+ * @param thd
+ * @param data
+ * @param num
+ * @param type
+ * @return
+ */
+std::string build_metadata_time_value_string(THD *thd, const void *data,
+                                             uint32_t num,
+                                             tiledb_datatype_t type);
+/**
  * Convert datetime to mysql standard string
  * @param thd
  * @param seconds

--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -549,7 +549,16 @@ int tile::set_range_from_item_datetime(THD *thd,
   case tiledb_datatype_t::TILEDB_DATETIME_NS:
   case tiledb_datatype_t::TILEDB_DATETIME_PS:
   case tiledb_datatype_t::TILEDB_DATETIME_FS:
-  case tiledb_datatype_t::TILEDB_DATETIME_AS: {
+  case tiledb_datatype_t::TILEDB_DATETIME_AS:
+  case tiledb_datatype_t::TILEDB_TIME_HR:
+  case tiledb_datatype_t::TILEDB_TIME_MIN:
+  case tiledb_datatype_t::TILEDB_TIME_SEC:
+  case tiledb_datatype_t::TILEDB_TIME_MS:
+  case tiledb_datatype_t::TILEDB_TIME_US:
+  case tiledb_datatype_t::TILEDB_TIME_NS:
+  case tiledb_datatype_t::TILEDB_TIME_PS:
+  case tiledb_datatype_t::TILEDB_TIME_FS:
+  case tiledb_datatype_t::TILEDB_TIME_AS: {
     if (lower_const != nullptr) {
       lower_const->get_date(thd, &lower_date, date_mode_t(0));
       lower = MysqlTimeToTileDBTimeVal(thd, lower_date, datatype);
@@ -931,7 +940,16 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
     case tiledb_datatype_t::TILEDB_DATETIME_NS:
     case tiledb_datatype_t::TILEDB_DATETIME_PS:
     case tiledb_datatype_t::TILEDB_DATETIME_FS:
-    case tiledb_datatype_t::TILEDB_DATETIME_AS: {
+    case tiledb_datatype_t::TILEDB_DATETIME_AS:
+    case tiledb_datatype_t::TILEDB_TIME_HR:
+    case tiledb_datatype_t::TILEDB_TIME_MIN:
+    case tiledb_datatype_t::TILEDB_TIME_SEC:
+    case tiledb_datatype_t::TILEDB_TIME_MS:
+    case tiledb_datatype_t::TILEDB_TIME_US:
+    case tiledb_datatype_t::TILEDB_TIME_NS:
+    case tiledb_datatype_t::TILEDB_TIME_PS:
+    case tiledb_datatype_t::TILEDB_TIME_FS:
+    case tiledb_datatype_t::TILEDB_TIME_AS: {
       MYSQL_TIME mysql_time;
       Field *field = key_part_info->field;
 

--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -794,8 +794,6 @@ int tile::set_time_field(THD *thd, Field *field, std::shared_ptr<buffer> &buff,
 
 int tile::set_field(THD *thd, Field *field, std::shared_ptr<buffer> &buff,
                     uint64_t i) {
-  const char *str;
-  tiledb_datatype_to_str(buff->type, &str);
   switch (buff->type) {
   /** 8-bit signed integer */
   case TILEDB_INT8:

--- a/mytile/mytile.h
+++ b/mytile/mytile.h
@@ -112,6 +112,15 @@ struct BufferSizeByType {
     case TILEDB_DATETIME_PS:
     case TILEDB_DATETIME_FS:
     case TILEDB_DATETIME_AS:
+    case TILEDB_TIME_HR:
+    case TILEDB_TIME_MIN:
+    case TILEDB_TIME_SEC:
+    case TILEDB_TIME_MS:
+    case TILEDB_TIME_US:
+    case TILEDB_TIME_NS:
+    case TILEDB_TIME_PS:
+    case TILEDB_TIME_FS:
+    case TILEDB_TIME_AS:
       return int64_buffer_size;
     default: {
       const char *str;
@@ -332,6 +341,20 @@ bool set_field_null_from_validity(std::shared_ptr<buffer> &buff, Field *field,
 int set_datetime_field(THD *thd, Field *field, std::shared_ptr<buffer> &buff,
                        uint64_t i, uint64_t seconds, uint64_t second_part,
                        enum_mysql_timestamp_type type);
+/**
+ * set field from time type
+ * @param thd
+ * @param field
+ * @param buff
+ * @param i
+ * @param seconds
+ * @param second_part
+ * @param type
+ * @return
+ */
+int set_time_field(THD *thd, Field *field, std::shared_ptr<buffer> &buff,
+                   uint64_t i, int64_t hours, int64_t minutes, int64_t seconds,
+                   int64_t second_part, enum_mysql_timestamp_type type);
 
 /**
  * Set field from type

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -14,14 +14,14 @@ git clone --recurse-submodules https://github.com/MariaDB/server.git -b ${MARIAD
 if [[ -z ${SUPERBUILD+x} || "${SUPERBUILD}" == "OFF" ]]; then
 
   if [[ "$AGENT_OS" == "Linux" ]]; then
-    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.9/tiledb-linux-2.2.9-dc3bb54-full.tar.gz \
+    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.0/tiledb-linux-2.3.0-a87da7f-full.tar.gz \
     && sudo tar -C /usr/local -xvf tiledb.tar.gz
   elif [[ "$AGENT_OS" == "Darwin" ]]; then
-    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.2.9/tiledb-macos-2.2.9-dc3bb54-full.tar.gz \
+    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.0/tiledb-macos-2.3.0-a87da7f-full.tar.gz \
     && sudo tar -C /usr/local -xvf tiledb.tar.gz
   else
     mkdir build_deps && cd build_deps \
-    && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.2.9 && cd TileDB \
+    && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.3.0 && cd TileDB \
     && mkdir -p build && cd build
 
      # Configure and build TileDB


### PR DESCRIPTION
This PR updates to TileDB 2.3 and adds support for the new TileDB Time datatypes to match the MariaDB TIME data type. Previously we were putting TIME types in `TILEDB_DATETIME` fields. Now we store them as proper `TILEDB_TIME_MS`.

No new unit tests are added because we already had unit tests for time datatypes, so they cover the new functionality.