### PR TITLE
Add QueryCondition pushdown support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ if(NOT TileDB_FOUND AND SUPERBUILD)
 
     SET(TILEDB_VERSION_MAJOR "2")
     SET(TILEDB_VERSION_MINOR "3")
-    SET(TILEDB_VERSION_PATCH "0")
+    SET(TILEDB_VERSION_PATCH "1")
     SET(TILEDB_VERSION "${TILEDB_VERSION_MAJOR}.${TILEDB_VERSION_MINOR}.${TILEDB_VERSION_PATCH}")
 
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=non-virtual-dtor")
     ExternalProject_Add(tiledb
             PREFIX "externals"
             URL "https://github.com/TileDB-Inc/TileDB/archive/${TILEDB_VERSION}.zip"
-            URL_HASH SHA1=eafcc0dc8d9608565ae2f40fd423c570de1f2e54
+            URL_HASH SHA1=6f73a6985ae40cd942a215821e60de2b747d9b5e
             DOWNLOAD_NAME "tiledb.zip"
             CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.3.0"
+ARG TILEDB_VERSION="2.3.1"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-R
+++ b/docker/Dockerfile-R
@@ -72,7 +72,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.3.0"
+ARG TILEDB_VERSION="2.3.1"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y \
 
 ENV MTR_MEM /tmp
 
-ARG TILEDB_VERSION="2.3.0"
+ARG TILEDB_VERSION="2.3.1"
 
 WORKDIR /tmp
 

--- a/docker/Dockerfile-min
+++ b/docker/Dockerfile-min
@@ -55,7 +55,7 @@ WORKDIR /tmp
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.3.0"
+ARG TILEDB_VERSION="2.3.1"
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 # Set git config so superbuild of tiledb can cherry-pick capnp fix

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -56,7 +56,7 @@ ENV MARIADB_VERSION="mariadb-10.4.18"
 
 ARG MYTILE_VERSION="0.8.1"
 
-ARG TILEDB_VERSION="2.3.0"
+ARG TILEDB_VERSION="2.3.1"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \

--- a/mysql-test/mytile/r/data_types.result
+++ b/mysql-test/mytile/r/data_types.result
@@ -259,18 +259,18 @@ column1	column2
 DROP TABLE t1;
 # UNSIGNED INTEGER
 CREATE TABLE t1 (
-column1 smallint unsigned dimension=1 lower_bound="0" upper_bound="65535" tile_extent="1"
+column1 smallint unsigned dimension=1 lower_bound="0" upper_bound="65534" tile_extent="1"
 ) ENGINE=mytile;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (-1);
 Warnings:
 Warning	1264	Out of range value for column 'column1' at row 1
-INSERT INTO t1 VALUES (65535);
+INSERT INTO t1 VALUES (65534);
 select * FROM t1 ORDER BY column1 ASC;
 column1
 0
 1
-65535
+65534
 DROP TABLE t1;
 # INT and VARCHAR
 CREATE TABLE t1 (

--- a/mysql-test/mytile/r/query_conditions.result
+++ b/mysql-test/mytile/r/query_conditions.result
@@ -1,0 +1,65 @@
+#
+# Test attribute query conditions for pushdown of predicates
+#
+CREATE TABLE `test_filter` (
+`id` int dimension=1 `lower_bound`="-10000" `upper_bound`="100000000" tile_extent="1",
+`a1` int not null,
+`a2` int default null,
+`a3` varchar(255) default null,
+`a4` varchar(255) not null,
+PRIMARY KEY(id)
+) ENGINE=MyTile;
+INSERT INTO test_filter VALUES (1, 1, 1, "1", "1"), (2, 2, NULL, NULL, "2"), (3, 300, 300, "abc", "def");
+INSERT INTO test_filter VALUES (1, 1, 10, "beef", "stew"), (2, 100, NULL, "test", "orange"), (3, 300, 400, "def", "beef");
+SELECT * FROM test_filter;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+2	100	NULL	test	orange
+3	300	400	def	beef
+SELECT * FROM test_filter WHERE a2 = 1;
+id	a1	a2	a3	a4
+SELECT * FROM test_filter WHERE a1 = 1;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+SELECT * FROM test_filter WHERE a3 = "1";
+id	a1	a2	a3	a4
+SELECT * FROM test_filter WHERE a4 = "1";
+id	a1	a2	a3	a4
+SELECT * FROM test_filter WHERE a2 BETWEEN 1 AND 11;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+SELECT * FROM test_filter WHERE a2 BETWEEN 1 AND 11 AND a3 = "beef";
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+SELECT * FROM test_filter WHERE a3 = "beef" AND a4 = "stew";
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+SELECT * FROM test_filter WHERE a1 != 1;
+id	a1	a2	a3	a4
+2	100	NULL	test	orange
+3	300	400	def	beef
+SELECT * FROM test_filter WHERE a1 > 300;
+id	a1	a2	a3	a4
+SELECT * FROM test_filter WHERE a1 < 300;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+2	100	NULL	test	orange
+SELECT * FROM test_filter WHERE a1 <= 300;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+2	100	NULL	test	orange
+3	300	400	def	beef
+SELECT * FROM test_filter WHERE a1 >= 300;
+id	a1	a2	a3	a4
+3	300	400	def	beef
+SELECT * FROM test_filter WHERE a2 IS NULL;
+id	a1	a2	a3	a4
+2	100	NULL	test	orange
+SELECT * FROM test_filter WHERE a3 IS NULL;
+id	a1	a2	a3	a4
+SELECT * FROM test_filter WHERE a2 IS NULL AND a3 IS NOT NULL;
+id	a1	a2	a3	a4
+2	100	NULL	test	orange
+SELECT * FROM test_filter WHERE a2 IS NOT NULL AND a3 IS NULL;
+id	a1	a2	a3	a4
+DROP TABLE test_filter;

--- a/mysql-test/mytile/t/data_types.test
+++ b/mysql-test/mytile/t/data_types.test
@@ -233,11 +233,11 @@ DROP TABLE t1;
 
 --echo # UNSIGNED INTEGER
 CREATE TABLE t1 (
-  column1 smallint unsigned dimension=1 lower_bound="0" upper_bound="65535" tile_extent="1"
+  column1 smallint unsigned dimension=1 lower_bound="0" upper_bound="65534" tile_extent="1"
 ) ENGINE=mytile;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (-1);
-INSERT INTO t1 VALUES (65535);
+INSERT INTO t1 VALUES (65534);
 select * FROM t1 ORDER BY column1 ASC;
 DROP TABLE t1;
 

--- a/mysql-test/mytile/t/query_conditions.test
+++ b/mysql-test/mytile/t/query_conditions.test
@@ -1,0 +1,34 @@
+--echo #
+--echo # Test attribute query conditions for pushdown of predicates
+--echo #
+
+CREATE TABLE `test_filter` (
+  `id` int dimension=1 `lower_bound`="-10000" `upper_bound`="100000000" tile_extent="1",
+  `a1` int not null,
+  `a2` int default null,
+  `a3` varchar(255) default null,
+  `a4` varchar(255) not null,
+  PRIMARY KEY(id)
+) ENGINE=MyTile;
+
+INSERT INTO test_filter VALUES (1, 1, 1, "1", "1"), (2, 2, NULL, NULL, "2"), (3, 300, 300, "abc", "def");
+INSERT INTO test_filter VALUES (1, 1, 10, "beef", "stew"), (2, 100, NULL, "test", "orange"), (3, 300, 400, "def", "beef");
+SELECT * FROM test_filter;
+SELECT * FROM test_filter WHERE a2 = 1;
+SELECT * FROM test_filter WHERE a1 = 1;
+SELECT * FROM test_filter WHERE a3 = "1";
+SELECT * FROM test_filter WHERE a4 = "1";
+SELECT * FROM test_filter WHERE a2 BETWEEN 1 AND 11;
+SELECT * FROM test_filter WHERE a2 BETWEEN 1 AND 11 AND a3 = "beef";
+SELECT * FROM test_filter WHERE a3 = "beef" AND a4 = "stew";
+SELECT * FROM test_filter WHERE a1 != 1;
+SELECT * FROM test_filter WHERE a1 > 300;
+SELECT * FROM test_filter WHERE a1 < 300;
+SELECT * FROM test_filter WHERE a1 <= 300;
+SELECT * FROM test_filter WHERE a1 >= 300;
+SELECT * FROM test_filter WHERE a2 IS NULL;
+SELECT * FROM test_filter WHERE a3 IS NULL;
+SELECT * FROM test_filter WHERE a2 IS NULL AND a3 IS NOT NULL;
+SELECT * FROM test_filter WHERE a2 IS NOT NULL AND a3 IS NULL;
+
+DROP TABLE test_filter;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -587,6 +587,9 @@ private:
   // TileDB Query
   std::shared_ptr<tiledb::Query> query;
 
+  // TileDB Query Condition
+  std::shared_ptr<tiledb::QueryCondition> query_condition;
+
   // Current record row
   uint64_t record_index = 0;
 

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -59,6 +59,9 @@ typedef struct range_struct {
   tiledb_datatype_t datatype;
   uint64_t lower_value_size;
   uint64_t upper_value_size;
+
+  tiledb::QueryCondition QueryCondition(const tiledb::Context &ctx,
+                                        const std::string &field_name) const;
 } range;
 
 int set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,

--- a/scripts/ci_install_tiledb_and_run_tests.sh
+++ b/scripts/ci_install_tiledb_and_run_tests.sh
@@ -14,14 +14,14 @@ git clone --recurse-submodules https://github.com/MariaDB/server.git -b ${MARIAD
 if [[ -z ${SUPERBUILD+x} || "${SUPERBUILD}" == "OFF" ]]; then
 
   if [[ "$AGENT_OS" == "Linux" ]]; then
-    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.0/tiledb-linux-2.3.0-a87da7f-full.tar.gz \
+    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.1/tiledb-linux-x86_64-2.3.1-6d36169.tar.gz \
     && sudo tar -C /usr/local -xvf tiledb.tar.gz
   elif [[ "$AGENT_OS" == "Darwin" ]]; then
-    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.0/tiledb-macos-2.3.0-a87da7f-full.tar.gz \
+    curl -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/releases/download/2.3.1/tiledb-macos-x86_64-2.3.1-6d36169.tar.gz \
     && sudo tar -C /usr/local -xvf tiledb.tar.gz
   else
     mkdir build_deps && cd build_deps \
-    && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.3.0 && cd TileDB \
+    && git clone https://github.com/TileDB-Inc/TileDB.git -b 2.3.1 && cd TileDB \
     && mkdir -p build && cd build
 
      # Configure and build TileDB


### PR DESCRIPTION
This pushes down filtering on the attribute field. This is currently limited to AND clauses with basic predicates of `>`/`>=`/`=`/`<=`/`<`/`!=` along with `IS NULL` and `IS NOT NULL`.

At this time I opted to re-use the existing range building functionality we have. This minimized the changes needed to start with.