### PR TITLE
Fix string pushdown for query condition and ranges

### DIFF
--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -487,6 +487,11 @@ int tile::set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,
     tile::set_range_from_item_consts<uint64_t>(thd, lower_const, upper_const,
                                                cmp_type, range, datatype);
     break;
+  case tiledb_datatype_t::TILEDB_CHAR:
+  case tiledb_datatype_t::TILEDB_STRING_ASCII:
+    tile::set_range_from_item_consts<char>(thd, lower_const, upper_const,
+                                           cmp_type, range, datatype);
+    break;
   default: {
     DBUG_RETURN(1);
   }

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -928,6 +928,7 @@ int set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,
   switch (cmp_type) {
     // TILED does not support string dimensions
   case STRING_RESULT: {
+    range->datatype = tiledb_datatype_t::TILEDB_STRING_ASCII;
     char buff[256];
     String *res, tmp(buff, sizeof(buff), &my_charset_bin);
     res = lower_const->val_str(&tmp);


### PR DESCRIPTION
This fixes four problems:
1) `set_range_from_item_consts` was missing switch case for strings, so pushdown via `cond_push` was not support previously (only through index pushdown)
2) We were not correctly checking and bailing early in `cond_push` when the condition was not a constant but was other fields
3) We incorrectly were supporting IN clauses for QueryCondition with pushdown of attribute fields. TileDB core library currently doesn't support `OR` or `IN` clauses for attribute pushdown
4) We were not exiting early in `cond_push` when we had an attribute that we couldn't use pushdown on, this causes error in trying to set ranges for dimensions instead in the fallback