### PR TITLE
Fix index handling in 10.5

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -3148,7 +3148,7 @@ int tile::mytile::build_mrr_ranges() {
             continue;
           }
         } else {
-          key_len += tiledb_datatype_size(datatype);
+          key_len += table->s->key_info[active_index].key_part[i].length;
         }
 
         if (key_offset + key_len >= mrr_cur_range.start_key.length)
@@ -3199,7 +3199,7 @@ int tile::mytile::build_mrr_ranges() {
             continue;
           }
         } else {
-          key_len += tiledb_datatype_size(datatype);
+          key_len += table->s->key_info[active_index].key_part[i].length;
         }
 
         if (key_offset + key_len >= mrr_cur_range.end_key.length)

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -471,7 +471,6 @@ int tile::mytile::create_array(const char *name, TABLE *table_arg,
         primaryKeyParts[field->field_name.str] = true;
 
         try {
-          std::cout << table_arg->s->table_name.str << " - " << field->field_name.str << std::endl;
           domain.add_dimension(create_field_dimension(context, field));
         } catch (const std::exception &e) {
           // Log errors
@@ -2700,15 +2699,14 @@ int8_t tile::mytile::compare_key_to_dims(const uchar *key, uint key_len,
        key_part_index < key_info->user_defined_key_parts; key_part_index++) {
 
     const KEY_PART_INFO *key_part_info = &(key_info->key_part[key_part_index]);
-    uint64_t dim_idx = key_part_info->field->field_index;
-    tiledb::Dimension dimension = domain.dimension(dim_idx);
+    tiledb::Dimension dimension = domain.dimension(key_part_index);
 
     for (auto &dim_buffer : this->buffers) {
       if (dim_buffer == nullptr || dim_buffer->name != dimension.name()) {
         continue;
       } else { // buffer for dimension was found
         uint8_t dim_comparison =
-            compare_key_to_dim(dim_idx, key + key_position,
+            compare_key_to_dim(key_part_index, key + key_position,
                                key_part_info->length, index, dim_buffer);
         key_position += key_part_info->length;
         if (dim_comparison != 0) {

--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -837,9 +837,8 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
     }
 
     const KEY_PART_INFO *key_part_info = &(key_info->key_part[key_part_index]);
-    uint64_t dim_idx = key_part_info->field->field_index;
 
-    tiledb_datatype_t datatype = domain.dimension(dim_idx).type();
+    tiledb_datatype_t datatype = domain.dimension(key_part_index).type();
 
     uint64_t key_len = 0;
     if (datatype == tiledb_datatype_t::TILEDB_STRING_ASCII) {
@@ -855,63 +854,63 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
 
     switch (datatype) {
     case tiledb_datatype_t::TILEDB_FLOAT64: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<double>(key + key_offset, length, find_flag,
                                        start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_FLOAT32: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<float>(key + key_offset, length, find_flag,
                                       start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_INT8: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<int8_t>(key + key_offset, length, find_flag,
                                        start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_UINT8: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<uint8_t>(key + key_offset, length, find_flag,
                                         start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_INT16: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<int16_t>(key + key_offset, length, find_flag,
                                         start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_UINT16: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<uint16_t>(key + key_offset, length, find_flag,
                                          start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_INT32: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<int32_t>(key + key_offset, length, find_flag,
                                         start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_UINT32: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<uint32_t>(key + key_offset, length, find_flag,
                                          start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_INT64: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<int64_t>(key + key_offset, length, find_flag,
                                         start_key, last_key_part, datatype);
       break;
@@ -930,7 +929,7 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
                                MYSQL_TIMESTAMP_TIME};
       int64_t xs = MysqlTimeToTileDBTimeVal(thd, mysql_time, datatype);
 
-      ranges[dim_idx] = build_range_from_key<int64_t>(
+      ranges[key_part_index] = build_range_from_key<int64_t>(
           (uchar *)&xs, length, find_flag, start_key, last_key_part, datatype);
       break;
     }
@@ -964,13 +963,13 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
       field->ptr = tmp;
       int64_t xs = MysqlTimeToTileDBTimeVal(thd, mysql_time, datatype);
 
-      ranges[dim_idx] = build_range_from_key<int64_t>(
+      ranges[key_part_index] = build_range_from_key<int64_t>(
           (uchar *)&xs, length, find_flag, start_key, last_key_part, datatype);
       break;
     }
 
     case tiledb_datatype_t::TILEDB_UINT64: {
-      ranges[dim_idx] =
+      ranges[key_part_index] =
           build_range_from_key<uint64_t>(key + key_offset, length, find_flag,
                                          start_key, last_key_part, datatype);
       break;
@@ -981,11 +980,11 @@ tile::build_ranges_from_key(THD *thd, const TABLE *table, const uchar *key,
           *reinterpret_cast<const uint16_t *>(key + key_offset);
       // If there is no string set the range to nullptr
       if (char_length == 0) {
-        ranges[dim_idx] = nullptr;
+        ranges[key_part_index] = nullptr;
         break;
       }
       key_offset += sizeof(uint16_t);
-      ranges[dim_idx] = build_range_from_key<char>(
+      ranges[key_part_index] = build_range_from_key<char>(
           key + key_offset, length, find_flag, start_key, last_key_part,
           datatype, char_length);
       break;

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -686,10 +686,13 @@ void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
   // TileDB ranges are inclusive
   case Item_func::GT_FUNC: {
     range->operation_type = Item_func::GE_FUNC;
-    if (std::is_floating_point<T>()) {
-      *key_value = std::nextafter(*key_value, std::numeric_limits<T>::max());
-    } else if (!std::is_same<T, char>()) {
-      *key_value += 1;
+    // Only increment last key part
+    if (last_key_part) {
+      if (std::is_floating_point<T>()) {
+        *key_value = std::nextafter(*key_value, std::numeric_limits<T>::max());
+      } else if (!std::is_same<T, char>()) {
+        *key_value += 1;
+      }
     }
 
     // If the lower is null, set it
@@ -753,10 +756,14 @@ void update_range_from_key_for_super_range(std::shared_ptr<tile::range> &range,
     // If we have less than, lets make it less than or equal
     // TileDB ranges are inclusive
     range->operation_type = Item_func::LE_FUNC;
-    if (std::is_floating_point<T>()) {
-      *key_value = std::nextafter(*key_value, std::numeric_limits<T>::min());
-    } else if (!std::is_same<T, char>()) {
-      *key_value -= 1;
+
+    // Only decrement last key part
+    if (last_key_part) {
+      if (std::is_floating_point<T>()) {
+        *key_value = std::nextafter(*key_value, std::numeric_limits<T>::min());
+      } else if (!std::is_same<T, char>()) {
+        *key_value -= 1;
+      }
     }
 
     // If the upper is null, set it

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -17,7 +17,7 @@ steps:
   displayName: 'Install system headers (OSX only)'
 
 - bash: |
-    set -e
+    set -v -e -x
     # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969
     if [[ "$AGENT_OS" == "Linux" ]]; then
       sudo chown root.root /
@@ -46,10 +46,10 @@ steps:
     fi
 
     if [[ "$AGENT_OS" == "Darwin" ]]; then
-      brew install cmake jemalloc traildb/judy/judy openssl boost gnutls m4 bison
-      export PATH="$(brew --prefix bison)/bin:$PATH"
+      brew install cmake jemalloc traildb/judy/judy openssl@1.1 boost gnutls m4 bison@2.7
+      export PATH="$(brew --prefix bison@2.7)/bin:$PATH"
 
-      export OSX_FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error -Wno-error=pointer-sign"
+      export OSX_FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error -Wno-error=pointer-sign -Wno-error=all"
       export CXXFLAGS="${CXXFLAGS} ${OSX_FLAGS_NEEDED}"
       export CFLAGS="${CFLAGS} ${OSX_FLAGS_NEEDED}"
       export DYLD_LIBRARY_PATH=$BUILD_REPOSITORY_LOCALPATH/build_deps/TileDB/dist/lib:$DYLD_LIBRARY_PATH


### PR DESCRIPTION
This PR has a few fixes, first we set the dimension order to be the same as the index orders. Next we properly handle MRR keys to only increment the last_key part. That is for MariaDB when using non-inclusive ranges, only the last part of the key is expected to be incremented.

Lastly we handle the key_length not being the same as the TileDB datatype.