### PR TITLE
Update server docker image to use prebuilt TileDB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,8 @@ RUN git config --global user.email "you@example.com" \
 # Install tiledb using 2.4 release
 RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
  && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
- && rm ${TILEDB_PREBUILT_FILE}
+ && rm ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
 
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \

--- a/docker/Dockerfile-R
+++ b/docker/Dockerfile-R
@@ -96,7 +96,8 @@ RUN git config --global user.email "you@example.com" \
 # Install tiledb using 2.4 release
 RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
  && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
- && rm  ${TILEDB_PREBUILT_FILE}
+ && rm  ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
 
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -64,7 +64,8 @@ RUN git config --global user.email "you@example.com" \
 # Install tiledb using 2.4 release
 RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
  && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
- && rm  ${TILEDB_PREBUILT_FILE}
+ && rm  ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
 
 ENV MARIADB_VERSION="mariadb-10.5.12"
 

--- a/docker/Dockerfile-min
+++ b/docker/Dockerfile-min
@@ -75,7 +75,8 @@ RUN cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
 # Install tiledb using 2.4 release
 RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
  && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
- && rm  ${TILEDB_PREBUILT_FILE}
+ && rm  ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
 
 # TODO change branch after release cut
 #RUN git clone https://github.com/TileDB-Inc/TileDB-MariaDB.git -b ${MYTILE_VERSION} mytile \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -57,6 +57,8 @@ ENV MARIADB_VERSION="mariadb-10.5.12"
 ARG MYTILE_VERSION="0.10.0"
 
 ARG TILEDB_VERSION="2.4.0"
+ARG TILEDB_VERSION_SHORT_SHA="baf64e1"
+ARG TILEDB_PREBUILT_FILE="tiledb-linux-x86_64-${TILEDB_VERSION}-${TILEDB_VERSION_SHORT_SHA}.tar.gz"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
@@ -74,13 +76,10 @@ RUN git config --global user.email "you@example.com" \
  && git config --global user.name "Your Name"
 
 # Install tiledb using 2.4 release
-RUN mkdir build_deps && cd build_deps \
- && git clone https://github.com/TileDB-Inc/TileDB.git -b ${TILEDB_VERSION} && cd TileDB \
- && mkdir -p build && cd build \
- && cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. \
- && make -j$(nproc) \
- && make -C tiledb install \
- && cd /tmp && rm -r build_deps
+RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
+ && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
+ && rm ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
 
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \


### PR DESCRIPTION
Update server docker image to use prebuilt TileDB. This fixes a timeout / reduces CI runtime for building the docker image. We use prebuilt library for all over docker images.