### PR TITLE
Check return code of `build_mrr_ranges`

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -3252,7 +3252,9 @@ int tile::mytile::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
 
   this->mrr_query = true;
 
-  build_mrr_ranges();
+  int rc = build_mrr_ranges();
+  if (rc)
+    DBUG_RETURN(rc);
 
   // Never use default implementation also use sort key access
   mode &= ~HA_MRR_USE_DEFAULT_IMPL;


### PR DESCRIPTION
This fixes a problem where errors in the init sequence of MRR were not causing the user to get the error returned to them. This fixes also a cause where we would segfault by continuing the query when it was not properly init'ed.