### PR TITLE
Remove unnecessary casting for Datetime pushdown

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1502,10 +1502,8 @@ const COND *tile::mytile::cond_push_func_datetime(const Item_func *func_item) {
       cmp_type = TIME_RESULT;
     }
 
-    int ret = set_range_from_item_datetime(
-        ha_thd(), dynamic_cast<Item_cache_datetime *>(args[1]),
-        dynamic_cast<Item_cache_datetime *>(args[1]), cmp_type, range,
-        datatype);
+    int ret = set_range_from_item_datetime(ha_thd(), args[1], args[1], cmp_type,
+                                           range, datatype);
 
     if (ret)
       DBUG_RETURN(func_item);
@@ -1529,11 +1527,12 @@ const COND *tile::mytile::cond_push_func_datetime(const Item_func *func_item) {
 
     break;
   }
-  case Item_func::BETWEEN:
+  case Item_func::BETWEEN: {
     neg = (dynamic_cast<const Item_func_opt_neg *>(func_item))->negated;
     if (neg) // don't support negations!
       DBUG_RETURN(func_item);
-    // fall through
+  }
+  // fall through
   case Item_func::LE_FUNC: // Handle all cases where there is 1 or 2 arguments
                            // we must set on
   case Item_func::LT_FUNC:

--- a/mytile/mytile-range.cc
+++ b/mytile/mytile-range.cc
@@ -500,10 +500,8 @@ int tile::set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,
   DBUG_RETURN(0);
 }
 
-int tile::set_range_from_item_datetime(THD *thd,
-                                       Item_cache_datetime *lower_const,
-                                       Item_cache_datetime *upper_const,
-                                       Item_result cmp_type,
+int tile::set_range_from_item_datetime(THD *thd, Item *lower_const,
+                                       Item *upper_const, Item_result cmp_type,
                                        std::shared_ptr<range> &range,
                                        tiledb_datatype_t datatype) {
   DBUG_ENTER("tile::set_range_from_item_datetime");

--- a/mytile/mytile-range.h
+++ b/mytile/mytile-range.h
@@ -70,8 +70,7 @@ int set_range_from_item_consts(THD *thd, Item_basic_constant *lower_const,
                                std::shared_ptr<tile::range> &range,
                                tiledb_datatype_t datatype);
 
-int set_range_from_item_datetime(THD *thd, Item_cache_datetime *lower_const,
-                                 Item_cache_datetime *upper_const,
+int set_range_from_item_datetime(THD *thd, Item *lower_const, Item *upper_const,
                                  Item_result cmp_type,
                                  std::shared_ptr<tile::range> &range,
                                  tiledb_datatype_t datatype);


### PR DESCRIPTION
This removes an unnecessary casting that was causing a segfault in the range pushdown for datetimes. There was an incorrect dynamic cast to change the Item pointer type. This is not needed and the `Item*` can be left as is.