### PR TITLE
Disable MRR by default

### DIFF
--- a/mysql-test/mytile/r/datetime_pushdown.result
+++ b/mysql-test/mytile/r/datetime_pushdown.result
@@ -256,7 +256,7 @@ DROP TABLE dt;
 CREATE TABLE datetime_dimensions ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/2.0/datetime_dimensions';;
 EXPLAIN SELECT dt_y FROM datetime_dimensions WHERE dt_y = 2020;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	datetime_dimensions	ref	PRIMARY	PRIMARY	1	const	1	Using index
+1	SIMPLE	datetime_dimensions	ref	PRIMARY	PRIMARY	1	const	10000	Using index
 SELECT dt_y FROM datetime_dimensions WHERE dt_y = 2020;
 dt_y
 2020

--- a/mysql-test/mytile/r/mrr.result
+++ b/mysql-test/mytile/r/mrr.result
@@ -1,6 +1,7 @@
 #
 # The purpose of this test is to validate the MRR functionality
 #
+SET mytile_mrr_support=1;
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 CREATE TABLE quickstart_sparse ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_sparse';;
 CREATE TABLE bank ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/2.0/bank';;
@@ -97,3 +98,4 @@ set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
 drop table `quickstart_sparse`;
 drop table `bank`;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/r/mrr_datetime_dimensions.result
+++ b/mysql-test/mytile/r/mrr_datetime_dimensions.result
@@ -1,6 +1,7 @@
 #
 # The purpose of this test is to validate MyTile datetime conditions with MRR
 #
+SET mytile_mrr_support=1;
 CREATE TABLE dt (
 column1 datetime(0) dimension=1 tile_extent="10",
 column2 int dimension=1 tile_extent="10",
@@ -56,3 +57,4 @@ column1	column2	column3	column3
 2020-09-20 08:00:00	9	sep	sep
 2020-10-20 09:00:00	10	oct	oct
 DROP TABLE dt;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/r/mrr_heterogeneus_dimensions.result
+++ b/mysql-test/mytile/r/mrr_heterogeneus_dimensions.result
@@ -1,6 +1,7 @@
 #
 # The purpose of this test is to build and query a table having heterogeneus dimensions with MRR functionality
 #
+SET mytile_mrr_support=1;
 # FLOAT32, INT64
 CREATE TABLE tmhd (d1 float dimension=1 lower_bound="1.0" upper_bound="20.0" tile_extent="5.0",
 d2 bigint dimension=1 lower_bound="1" upper_bound="30" tile_extent="5",
@@ -78,3 +79,4 @@ d1	d2	a	a
 1.6	6	6	6
 set mytile_delete_arrays=0;
 DROP TABLE tmhd;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/r/mrr_incomplete_queries.result
+++ b/mysql-test/mytile/r/mrr_incomplete_queries.result
@@ -1,6 +1,7 @@
 #
 # The purpose of this test is to validate the MRR functionality with incomplete TileDB queries
 #
+SET mytile_mrr_support=1;
 set mytile_read_buffer_size=16;
 CREATE TABLE quickstart_dense ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';;
 CREATE TABLE quickstart_sparse ENGINE=mytile uri='MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_sparse';;
@@ -112,3 +113,4 @@ rows	cols	a	a
 set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
 drop table `quickstart_sparse`;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/r/mrr_string_dim.result
+++ b/mysql-test/mytile/r/mrr_string_dim.result
@@ -2,6 +2,7 @@
 # The purpose of this test is to build and query a table having heterogeneus dimensions with MRR functionality
 # including string dimension
 #
+SET mytile_mrr_support=1;
 # FLOAT32, VARCHAR
 CREATE TABLE tmhds (d1 float dimension=1 lower_bound="1.0" upper_bound="20.0" tile_extent="5.0",
 d2 varchar(255) dimension=1, a int
@@ -154,3 +155,4 @@ d1	d2	a	a
 2020-06-01	jun	6	6
 set mytile_delete_arrays=0;
 DROP TABLE tmhds2;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/t/mrr.test
+++ b/mysql-test/mytile/t/mrr.test
@@ -1,6 +1,7 @@
 --echo #
 --echo # The purpose of this test is to validate the MRR functionality
 --echo #
+SET mytile_mrr_support=1;
 
 --replace_result $MTR_SUITE_DIR MTR_SUITE_DIR
 --eval CREATE TABLE quickstart_dense ENGINE=mytile uri='$MTR_SUITE_DIR/test_data/tiledb_arrays/1.6/quickstart_dense';
@@ -64,3 +65,4 @@ set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
 drop table `quickstart_sparse`;
 drop table `bank`;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/t/mrr_datetime_dimensions.test
+++ b/mysql-test/mytile/t/mrr_datetime_dimensions.test
@@ -2,6 +2,7 @@
 --echo # The purpose of this test is to validate MyTile datetime conditions with MRR
 --echo #
 
+SET mytile_mrr_support=1;
 #echo ranges
 CREATE TABLE dt (
   column1 datetime(0) dimension=1 tile_extent="10",
@@ -35,3 +36,4 @@ SELECT * from dt WHERE column1 > '2020-02-20 01:00:00' AND column1 < '2020-09-20
 SELECT * from dt WHERE column1 between '2020-06-20 05:00:00' AND '2020-10-20 09:00:00' AND column2 = 7;
 SELECT * from dt inner join dt dt2 USING(column1, column2);
 DROP TABLE dt;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/t/mrr_heterogeneus_dimensions.test
+++ b/mysql-test/mytile/t/mrr_heterogeneus_dimensions.test
@@ -1,6 +1,7 @@
 --echo #
 --echo # The purpose of this test is to build and query a table having heterogeneus dimensions with MRR functionality
 --echo #
+SET mytile_mrr_support=1;
 
 --echo # FLOAT32, INT64
 CREATE TABLE tmhd (d1 float dimension=1 lower_bound="1.0" upper_bound="20.0" tile_extent="5.0",
@@ -50,3 +51,4 @@ select * from `tmhd` a JOIN `tmhd` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2 asc
 
 set mytile_delete_arrays=0;
 DROP TABLE tmhd;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/t/mrr_incomplete_queries.test
+++ b/mysql-test/mytile/t/mrr_incomplete_queries.test
@@ -1,6 +1,7 @@
 --echo #
 --echo # The purpose of this test is to validate the MRR functionality with incomplete TileDB queries
 --echo #
+SET mytile_mrr_support=1;
 
 set mytile_read_buffer_size=16;
 
@@ -57,3 +58,4 @@ select * from `quickstart_dense` a JOIN `quickstart_sparse` b USING(`rows`, `col
 set mytile_delete_arrays=0;
 drop table `quickstart_dense`;
 drop table `quickstart_sparse`;
+SET mytile_mrr_support=0;

--- a/mysql-test/mytile/t/mrr_string_dim.test
+++ b/mysql-test/mytile/t/mrr_string_dim.test
@@ -2,6 +2,7 @@
 --echo # The purpose of this test is to build and query a table having heterogeneus dimensions with MRR functionality
 -- echo # including string dimension
 --echo #
+SET mytile_mrr_support=1;
 
 --echo # FLOAT32, VARCHAR
 CREATE TABLE tmhds (d1 float dimension=1 lower_bound="1.0" upper_bound="20.0" tile_extent="5.0",
@@ -99,3 +100,4 @@ select * from `tmhds2` a JOIN `tmhds2` b USING(`d1`, `d2`) ORDER BY `d1` asc, d2
 
 set mytile_delete_arrays=0;
 DROP TABLE tmhds2;
+SET mytile_mrr_support=0;

--- a/mytile/mytile-sysvars.cc
+++ b/mytile/mytile-sysvars.cc
@@ -117,6 +117,11 @@ static MYSQL_THDVAR_BOOL(create_allow_subset_existing_array,
                          "Allow registering a subset of column", NULL, NULL,
                          false);
 
+static MYSQL_THDVAR_BOOL(mrr_support,
+                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_THDLOCAL,
+                         "Should MRR support be enabled for queries", NULL, NULL,
+                         false);
+
 const char *log_level_names[] = {"error", "warning", "info", "debug", NullS};
 
 TYPELIB log_level_typelib = {array_elements(log_level_names) - 1,
@@ -138,6 +143,7 @@ struct st_mysql_sys_var *mytile_system_variables[] = {
     MYSQL_SYSVAR(compute_table_records),
     MYSQL_SYSVAR(log_level),
     MYSQL_SYSVAR(create_allow_subset_existing_array),
+    MYSQL_SYSVAR(mrr_support),
     NULL};
 
 ulonglong read_buffer_size(THD *thd) { return THDVAR(thd, read_buffer_size); }
@@ -173,6 +179,10 @@ my_bool compute_table_records(THD *thd) {
 
 my_bool create_allow_subset_existing_array(THD *thd) {
   return THDVAR(thd, create_allow_subset_existing_array);
+}
+
+my_bool mrr_support(THD *thd) {
+  return THDVAR(thd, mrr_support);
 }
 
 LOG_LEVEL log_level(THD *thd) { return LOG_LEVEL(THDVAR(thd, log_level)); }

--- a/mytile/mytile-sysvars.h
+++ b/mytile/mytile-sysvars.h
@@ -67,6 +67,8 @@ my_bool compute_table_records(THD *thd);
 
 my_bool create_allow_subset_existing_array(THD *thd);
 
+my_bool mrr_support(THD *thd);
+
 LOG_LEVEL log_level(THD *thd);
 } // namespace sysvars
 } // namespace tile


### PR DESCRIPTION
RR is most useful for joins and bulk key access (BKA). MariaDB however also attempts to use MRR if implemented for quick selects. This introduces a new sysvar `mytile_mrr_support` which toggles whether MRR is enabled or if its treated as disable and unavailable.

[sc-18106]