### PR TITLE
Add nightly build with GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,38 @@
+name: nightly
+on:
+  push:
+    paths:
+      - '.github/workflows/nightly.yaml'
+      - 'scripts/nightly/**'
+  schedule:
+    - cron: "0 2 * * *" # Every night at 2 AM UTC (9 PM EST; 10 PM EDT)
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    name: nightly-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-12", "ubuntu-20.04"]
+    env:
+      OWNER_TILEDB_MARIADB: ${{ github.repository_owner }} # support building from a fork
+      REF_MARIADB: mariadb-10.5.13
+      REF_LIBTILEDB: dev
+      REF_TILEDB_MARIADB: ${{ github.sha }}
+      TILEDB_FORCE_ALL_DEPS: OFF
+    steps:
+      # This initial checkout is only to obtain the CI scripts
+      - uses: actions/checkout@v3
+      - name: Clone and checkout repos
+        run: bash scripts/nightly/checkout.sh
+      - name: Setup Ubuntu
+        if: runner.os == 'Linux'
+        run: sudo bash scripts/nightly/setup-ubuntu.sh
+      - name: Setup macOS
+        if: runner.os == 'macOS'
+        run: bash scripts/nightly/setup-macos.sh
+      - name: Build libtiledb
+        run: bash scripts/nightly/build-libtiledb.sh
+      - name: Build TileDB-MariaDB
+        run: bash scripts/nightly/build-tiledb-mariadb.sh

--- a/scripts/nightly/build-libtiledb.sh
+++ b/scripts/nightly/build-libtiledb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eux
+
+# Build libtiledb from source
+
+cd libtiledb
+mkdir -p build
+cd build
+cmake \
+  -DTILEDB_VERBOSE=ON \
+  -DTILEDB_S3=ON \
+  -DTILEDB_SERIALIZATION=ON \
+  -DCMAKE_BUILD_TYPE=Debug \
+  ..
+make -j2
+sudo make -C tiledb install

--- a/scripts/nightly/build-tiledb-mariadb.sh
+++ b/scripts/nightly/build-tiledb-mariadb.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eux
+
+# Build TileDB-MariaDB
+
+OS=$(uname)
+if [[ "$OS" == "Linux" ]]
+then
+  FLAGS_NEEDED="-Wno-error=deprecated-declarations"
+  export LD_LIBRARY_PATH=$(pwd)/libtiledb/build_deps/TileDB/dist/lib:/usr/local/lib:${LD_LIBRARY_PATH-}
+  echo $LD_LIBRARY_PATH
+elif [[ "$OS" == "Darwin" ]]
+then
+  FLAGS_NEEDED="-Wno-error=enum-conversion -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=incompatible-function-pointer-types -Wno-error=writable-strings -Wno-writable-strings -Wno-write-strings -Wno-error -Wno-error=pointer-sign -Wno-error=all -Wno-error=unknown-warning-option -Wno-error=unused-but-set-variable -Wno-error=deprecated-copy-with-user-provided-copy"
+  export PATH="$(brew --prefix bison@2.7)/bin:$PATH"
+  export DYLD_LIBRARY_PATH=$(pwd)/libtiledb/build_deps/TileDB/dist/lib:/usr/local/lib:${DYLD_LIBRARY_PATH-}
+  echo $DYLD_LIBRARY_PATH
+else
+  echo "Unrecognized OS: $OS"
+  exit 1
+fi
+
+export CXXFLAGS="${CXXFLAGS-} ${FLAGS_NEEDED}"
+export CFLAGS="${CFLAGS-} ${FLAGS_NEEDED}"
+
+cd mariadb
+mkdir builddir
+cd builddir
+cmake \
+  -DPLUGIN_OQGRAPH=NO \
+  -DWITH_MARIABACKUP=OFF \
+  -DPLUGIN_TOKUDB=NO \
+  -DPLUGIN_ROCKSDB=NO \
+  -DPLUGIN_MROONGA=NO \
+  -DPLUGIN_SPIDER=NO \
+  -DPLUGIN_SPHINX=NO \
+  -DPLUGIN_FEDERATED=NO \
+  -DPLUGIN_FEDERATEDX=NO \
+  -DPLUGIN_CONNECT=NO \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DWITH_DEBUG=1 \
+  -DTILEDB_FORCE_ALL_DEPS=${TILEDB_FORCE_ALL_DEPS-NO} \
+  ..
+make -j2
+./mysql-test/mysql-test-run.pl --suite=mytile --debug

--- a/scripts/nightly/checkout.sh
+++ b/scripts/nightly/checkout.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eux
+
+# Checkout Git repositories
+
+OWNER_TILEDB_MARIADB=${OWNER_TILEDB_MARIADB-TileDB-Inc}
+REF_LIBTILEDB=${REF_LIBTILEDB-dev}
+REF_MARIADB=${REF_MARIADB-mariadb-10.5.13}
+REF_TILEDB_MARIADB=${REF_TILEDB_MARIADB-HEAD}
+
+git clone https://github.com/TileDB-Inc/TileDB.git libtiledb
+git -C libtiledb checkout "${REF_LIBTILEDB}"
+
+git clone https://github.com/MariaDB/server.git mariadb
+git -C mariadb checkout "${REF_MARIADB}"
+
+git clone https://github.com/${OWNER_TILEDB_MARIADB}/TileDB-MariaDB.git mariadb/storage/mytile
+git -C mariadb/storage/mytile checkout "${REF_TILEDB_MARIADB}"

--- a/scripts/nightly/setup-macos.sh
+++ b/scripts/nightly/setup-macos.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eux
+
+# Install dependencies on macOS
+
+brew install \
+  bison@2.7 \
+  boost \
+  cmake \
+  gnutls \
+  jemalloc \
+  m4 \
+  openssl@1.1 \
+  traildb/judy/judy

--- a/scripts/nightly/setup-ubuntu.sh
+++ b/scripts/nightly/setup-ubuntu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eux
+
+# Install dependencies on Ubuntu
+
+apt-get update
+apt-get install --yes \
+  bison \
+  gdb \
+  libncurses5-dev


### PR DESCRIPTION
**Summary:** This PR adds a GitHub Actions workflow to build and test the latest TileDB-MariaDB with the latest libtiledb every night

Notes:

* Translated from the existing Azure pipeline. I was able to simplify by removing Azure-specific steps, and also the nightly build doesn't need to test `SUPERBUILD=OFF`
* Did my best to remove any GitHub Actions specific functionality. This makes it possible to run the entire pipeline locally, eg
    ```sh
    bash scripts/nightly/checkout.sh
    bash scripts/nightly/setup-ubuntu.sh
    bash scripts/nightly/build-libtiledb.sh
    bash scripts/nightly/build-tiledb-mariadb.sh
    ```

Plans for future improvements:

* Currently the CI scripts download and build the latest libtiledb from source. The next step is to modify `CMakeLists.txt` to have the option to automatically build the latest libtiledb from source
* Automatically open an Issue for a failed build
