### PR TITLE
Open Issue for failed nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,3 +36,21 @@ jobs:
         run: bash scripts/nightly/build-libtiledb.sh
       - name: Build TileDB-MariaDB
         run: bash scripts/nightly/build-tiledb-mariadb.sh
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure() || cancelled()
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: "America/New_York"
+        run: |
+          gh issue create \
+            --assignee Shelnutt2,ihnorton,jdblischak \
+            --body "Nightly build failed in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)" \
+            --label "bug" \
+            --title "Nightly build failed on $(date '+%A (%Y-%m-%d)')"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,5 +52,5 @@ jobs:
           gh issue create \
             --assignee Shelnutt2,ihnorton,jdblischak \
             --body "Nightly build failed in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)" \
-            --label "bug" \
+            --label "nightly-failure" \
             --title "Nightly build failed on $(date '+%A (%Y-%m-%d)')"


### PR DESCRIPTION
Notes:

* Opens an Issue using the GitHub CLI command `gh issue create`. See [docs](https://cli.github.com/manual/gh_issue_create) for available flags
* Inspired by the [functionality](https://github.com/TileDB-Inc/TileDB-Py/blob/4f9ed6aedd5c4e499beb533378305ced6d29520f/.github/workflows/daily-test-build.yml#L78) in the TileDB-Py nightly build
* Issue includes a link to the failed run

Questions:

* Should any other users be automatically assigned to the Issue?
* Can only use existing Issue labels. Instead of generic "bug", should we create a specific one, eg "nightly"? This would make it easier to filter these automated Issues from other bug reports