### PR TITLE
Add tiledb version to show status

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -41,6 +41,7 @@
 #include "ha_mytile.h"
 #include "mytile-errors.h"
 #include "mytile-discovery.h"
+#include "mytile-statusvars.h"
 #include "mytile-sysvars.h"
 #include "mytile-metadata.h"
 #include "mytile.h"
@@ -3378,7 +3379,7 @@ mysql_declare_plugin(mytile){
     mytile_init_func,           /* Plugin Init */
     NULL,                       /* Plugin Deinit */
     0x0192,                     /* version number (0.19.2) */
-    NULL,                       /* status variables */
+    tile::statusvars::mytile_status_variables, /* status variables */
     tile::sysvars::mytile_system_variables, /* system variables */
     NULL,                                   /* config options */
     0,                                      /* flags */
@@ -3395,7 +3396,7 @@ maria_declare_plugin(mytile){
     mytile_init_func,           /* Plugin Init */
     NULL,                       /* Plugin Deinit */
     0x0192,                     /* version number (0.19.2) */
-    NULL,                       /* status variables */
+    tile::statusvars::mytile_status_variables, /* status variables */
     tile::sysvars::mytile_system_variables, /* system variables */
     "0.19.2",                               /* string version */
     MariaDB_PLUGIN_MATURITY_BETA            /* maturity */

--- a/mytile/mytile-statusvars.cc
+++ b/mytile/mytile-statusvars.cc
@@ -1,0 +1,56 @@
+/**
+ * @file   mytile-statusvars.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This declares the status variables
+ */
+
+#include <my_global.h> // ulonglong
+#include <handler.h>
+#include <tiledb/tiledb.h>
+#include "mytile-statusvars.h"
+#include <tiledb/tiledb>
+
+namespace tile {
+namespace statusvars {
+static int show_tiledb_version(MYSQL_THD thd, struct st_mysql_show_var *var,
+                               char *buf) {
+  auto version = tiledb::version();
+  var->type = SHOW_CHAR;
+  var->value = buf; // it's of SHOW_VAR_FUNC_BUFF_SIZE bytes
+  my_snprintf(buf, SHOW_VAR_FUNC_BUFF_SIZE, "%lu.%lu.%lu", std::get<0>(version),
+              std::get<1>(version), std::get<2>(version));
+
+  return 0;
+}
+
+struct st_mysql_show_var mytile_status_variables[] = {
+    {"mytile_tiledb_version", (char *)show_tiledb_version, SHOW_SIMPLE_FUNC},
+};
+} // namespace statusvars
+} // namespace tile

--- a/mytile/mytile-statusvars.h
+++ b/mytile/mytile-statusvars.h
@@ -1,0 +1,51 @@
+/**
+ * @file   mytile-statusvars.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This declares the status variables for the storage engine
+ */
+
+#pragma once
+
+#ifndef MYTILE_STATUSVARS_H
+#define MYTILE_STATUSVARS_H
+
+#define MYSQL_SERVER 1 // required for THD class
+
+#include <handler.h>
+#include <my_global.h>
+
+namespace tile {
+namespace statusvars {
+
+// list of system parameters
+extern struct st_mysql_show_var mytile_status_variables[];
+} // namespace statusvars
+} // namespace tile
+
+#endif // MYTILE_STATUSVARS_H


### PR DESCRIPTION
This introduces a new status variable for the TileDB version. 

```
MariaDB [(none)]> show status like '%mytile%';
+-----------------------+--------+
| Variable_name         | Value  |
+-----------------------+--------+
| Mytile_tiledb_version | 2.12.3 |
+-----------------------+--------+
1 row in set (0.001 sec)
```