### PR TITLE
Improve auto issue opening when a nightly build fails

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,16 +41,11 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     needs: build
-    if: failure() || cancelled()
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v3
       - name: Open Issue
         env:
           GH_TOKEN: ${{ github.token }}
           TZ: "America/New_York"
-        run: |
-          gh issue create \
-            --assignee Shelnutt2,ihnorton,jdblischak \
-            --body "Nightly build failed in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)" \
-            --label "nightly-failure" \
-            --title "Nightly build failed on $(date '+%A (%Y-%m-%d)')"
+        run: bash scripts/nightly/open-issue.sh

--- a/scripts/nightly/open-issue.sh
+++ b/scripts/nightly/open-issue.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ex
+
+# Open new Issue (or comment on existing) after build failure
+
+if [[ -z "$GH_TOKEN" ]]
+then
+  echo "The env var GH_TOKEN is missing"
+  echo "Please define it as a GitHub PAT with write permissions to Issues"
+  exit 1
+fi
+
+theDate="$(date '+%A (%Y-%m-%d)')"
+theMessage="Nightly build failed on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+
+existing=$(gh issue list \
+  --label "nightly-failure" \
+  --limit 1 \
+  --jq '.[].number' \
+  --json "number" \
+  --state "open")
+
+if [[ -z "$existing" ]]
+then
+  # open new issue
+  gh issue create \
+    --assignee Shelnutt2,ihnorton \
+    --body "$theMessage" \
+    --label "nightly-failure" \
+    --title "Nightly build failed on $theDate"
+else
+  # comment on existing issue
+  gh issue comment "$existing" \
+    --body "$theMessage"
+fi
+
+echo "Success!"


### PR DESCRIPTION
I made the following improvements to the issue-opening functionality:

* An Issue will only be opened if the build fails in a scheduled build on the main repo. In other words, it won't try to open an Issue on a fork, and it also won't attempt to open an Issue when building from a push to a branch or pull request. The advantage is that we can still test updates to the nightly build (eg enable a feature) without always opening an Issue
* When a scheduled nightly build fails, it will only create a new Issue if one doesn't currently exist. If there is already an open Issue with the label "nightly-failure", it simply comments with a link to the latest failed build log
* I removed my username from `--assignee`. Since I don't have write access to this repo, I can't be assigned to Issues

Note that the nightly build is currently failing (hence the motivation to comment on existing Issues)

CC: @ihnorton 
xref: #216