### PR TITLE
fixing issue 242

### DIFF
--- a/scripts/nightly/build-libtiledb.sh
+++ b/scripts/nightly/build-libtiledb.sh
@@ -7,6 +7,7 @@ cd libtiledb
 mkdir -p build
 cd build
 cmake \
+  -DCMAKE_INSTALL_PREFIX=/usr/local/ \
   -DTILEDB_VERBOSE=ON \
   -DTILEDB_S3=ON \
   -DTILEDB_SERIALIZATION=ON \


### PR DESCRIPTION
This PR fixes issue #242. The problem was that libtiledb could not be found by ```find_package(TileDB QUIET)```. The issue was resolved by adding the ```--prefix``` cmake flag. 
