### PR TITLE
fix string dim slicing bug

### DIFF
--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -480,9 +480,17 @@ public:
                             const std::shared_ptr<buffer> &buf);
 
   template <typename T>
-  int8_t compare_key_to_dim(const uchar *key, uint64_t key_length,
-                            const void *buffer,
+  int8_t compare_key_to_dim(const uint64_t dim_index, const uchar *key,
+                            uint64_t key_length, const void *buffer,
                             uint64_t buffer_size = sizeof(T)) {
+    // if a dim has zero ranges, return 0 (key == buffer)
+    const auto &ranges = this->pushdown_ranges[dim_index];
+    const auto &in_ranges = this->pushdown_in_ranges[dim_index];
+
+    if (ranges.empty() && in_ranges.empty()) {
+      return 0;
+    }
+
     // If the lower is null, set it
     if (std::is_same<T, char>()) {
       auto cmp = memcmp(buffer, key, std::min(key_length, buffer_size));


### PR DESCRIPTION
Read shortcut story for more details about the bug. 

I reproduced it locally by downloading the TileDB array stored in s3 https://cloud.tiledb.com/arrays/details/TileDB-Inc/504e9cc6-e8c4-4609-a5a4-1d243a9a7d1b/overview. 

The bug was happening when we were reading an array with dims of mixed type. (String and Numeric). More specifically,  when filtering on the String dim only, MyTile was failing to verify that the other dim matched the MariaDB key. This checking algorithm is part of MyTile  and was modified to avoid the bug. 

I am not including any new tests in this PR since the only array (as far as I know) that had this bug is 600MB. In smaller arrays the bug was not present. (Multiple read batches are required). 

A full reproduction can be found here: https://cloud.tiledb.com/notebooks/details/dstara/68c1c8c9-9209-4c34-bb1e-dabfc3ce9869/overview

Other than the bug fix, this PR also includes a minor code change which, after debugging, I found out that was adding the same range for each dimension multiple times and by multiple times I mean  ```X```(read-batches)