### PR TITLE
Add a pushdown for geometry types

### DIFF
--- a/mysql-test/mytile/r/spatial_index.result
+++ b/mysql-test/mytile/r/spatial_index.result
@@ -1,0 +1,48 @@
+# SPATIAL INDEX PUSHDOWN
+# Create a test array 
+create table t1 (
+_X           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+_Y           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+name         varchar(255) filters="GZIP=-1",
+wkb_geometry blob NOT NULL
+)
+engine=MyTile
+array_type='SPARSE'
+;
+# Insert 2 polygon geometries
+set @g1 = GeometryFromText('POLYGON((10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0))');
+set @g2 = GeometryFromText('POLYGON((84.0 84.0, 94.0 84.0, 94.0 94.0, 84.0 94.0, 84.0 84.0))');
+set @bbox1 = ST_Centroid(ST_Envelope(@g1));
+set @bbox2 = ST_Centroid(ST_Envelope(@g2));
+insert into t1 (_X, _Y, name, wkb_geometry) values
+(ST_X(@bbox1), ST_Y(@bbox1), "building1", aswkb(@g1)),
+(ST_X(@bbox2), ST_Y(@bbox2), "building2", aswkb(@g2))
+;
+# Test that only one intersects a search radius
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+GeometryFromWkb(wkb_geometry)
+);
+name	ST_Area(GeometryFromWkb(wkb_geometry))
+building2	100
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '\x00\x00\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x7F\x00\x00\x00\x00\x00\x00\x00\x00\x80V@\x00\x00\x00\x00\x00\x00T@\xB2\...'
+# Test again, but without the spatial index
+# (results should be identical, but without pushdown to _X _Y)
+set @mytile_enable_pushdown = false;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+GeometryFromWkb(wkb_geometry)
+);
+name	ST_Area(GeometryFromWkb(wkb_geometry))
+building2	100
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '\x00\x00\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x7F\x00\x00\x00\x00\x00\x00\x00\x00\x80V@\x00\x00\x00\x00\x00\x00T@\xB2\...'
+set @mytile_enable_pushdown = true;
+drop table t1;

--- a/mysql-test/mytile/r/spatial_index.result
+++ b/mysql-test/mytile/r/spatial_index.result
@@ -1,8 +1,8 @@
 # SPATIAL INDEX PUSHDOWN
 # Create a test array 
 create table t1 (
-_X           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
-_Y           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+_X           double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+_Y           double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
 name         varchar(255) filters="GZIP=-1",
 wkb_geometry blob NOT NULL
 )
@@ -12,13 +12,15 @@ array_type='SPARSE'
 # Insert 2 polygon geometries
 set @g1 = GeometryFromText('POLYGON((10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0))');
 set @g2 = GeometryFromText('POLYGON((84.0 84.0, 94.0 84.0, 94.0 94.0, 84.0 94.0, 84.0 84.0))');
-set @bbox1 = ST_Centroid(ST_Envelope(@g1));
-set @bbox2 = ST_Centroid(ST_Envelope(@g2));
+set @centroid1 = ST_Centroid(ST_Envelope(@g1));
+set @centroid2 = ST_Centroid(ST_Envelope(@g2));
 insert into t1 (_X, _Y, name, wkb_geometry) values
-(ST_X(@bbox1), ST_Y(@bbox1), "building1", aswkb(@g1)),
-(ST_X(@bbox2), ST_Y(@bbox2), "building2", aswkb(@g2))
+(ST_X(@centroid1), ST_Y(@centroid1), "building1", aswkb(@g1)),
+(ST_X(@centroid2), ST_Y(@centroid2), "building2", aswkb(@g2))
 ;
-# Test that only one intersects a search radius
+# Test all spatial binary predicates that use the spatial index
+# They should all match 'building 2'
+# INTERSECTS
 set @point_text = 'POINT(90.0 90.0)';
 set @buffer_distance = 10;
 select name, ST_Area(GeometryFromWkb(wkb_geometry))
@@ -31,8 +33,42 @@ name	ST_Area(GeometryFromWkb(wkb_geometry))
 building2	100
 Warnings:
 Warning	1292	Truncated incorrect DOUBLE value: '\x00\x00\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x7F\x00\x00\x00\x00\x00\x00\x00\x00\x80V@\x00\x00\x00\x00\x00\x00T@\xB2\...'
+# INTERSECTS, confirm pushdown in explain
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
+explain select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+GeometryFromWkb(wkb_geometry)
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100000	Using where with pushed condition
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '\x00\x00\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x7F\x00\x00\x00\x00\x00\x00\x00\x00\x80V@\x00\x00\x00\x00\x00\x00T@\xB2\...'
+# OVERLAPS
+set @point_text = 'POINT(70.0 70.0)';
+set @buffer_distance = 25;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Overlaps(
+ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+GeometryFromWkb(wkb_geometry)
+);
+name	ST_Area(GeometryFromWkb(wkb_geometry))
+building2	100
+Warnings:
+Warning	1292	Truncated incorrect DOUBLE value: '\x00\x00\x00\x00\x01\x03\x00\x00\x00\x01\x00\x00\x00\x7F\x00\x00\x00\x00\x00\x00\x00\x00\x80Q@\x00\x00\x00\x00\x00\x80F@\xBD\...'
+# EQUALS
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_EQUALS(@g2, GeometryFromWkb(wkb_geometry));
+name	ST_Area(GeometryFromWkb(wkb_geometry))
+building2	100
 # Test again, but without the spatial index
 # (results should be identical, but without pushdown to _X _Y)
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
 set @mytile_enable_pushdown = false;
 select name, ST_Area(GeometryFromWkb(wkb_geometry))
 from t1

--- a/mysql-test/mytile/t/spatial_index.test
+++ b/mysql-test/mytile/t/spatial_index.test
@@ -2,8 +2,8 @@
 
 --echo # Create a test array 
 create table t1 (
-  _X           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
-  _Y           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  _X           double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+  _Y           double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
   name         varchar(255) filters="GZIP=-1",
   wkb_geometry blob NOT NULL
 )
@@ -14,14 +14,17 @@ array_type='SPARSE'
 --echo # Insert 2 polygon geometries
 set @g1 = GeometryFromText('POLYGON((10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0))');
 set @g2 = GeometryFromText('POLYGON((84.0 84.0, 94.0 84.0, 94.0 94.0, 84.0 94.0, 84.0 84.0))');
-set @bbox1 = ST_Centroid(ST_Envelope(@g1));
-set @bbox2 = ST_Centroid(ST_Envelope(@g2));
+set @centroid1 = ST_Centroid(ST_Envelope(@g1));
+set @centroid2 = ST_Centroid(ST_Envelope(@g2));
 insert into t1 (_X, _Y, name, wkb_geometry) values
-  (ST_X(@bbox1), ST_Y(@bbox1), "building1", aswkb(@g1)),
-  (ST_X(@bbox2), ST_Y(@bbox2), "building2", aswkb(@g2))
+  (ST_X(@centroid1), ST_Y(@centroid1), "building1", aswkb(@g1)),
+  (ST_X(@centroid2), ST_Y(@centroid2), "building2", aswkb(@g2))
 ;
 
---echo # Test that only one intersects a search radius
+--echo # Test all spatial binary predicates that use the spatial index
+--echo # They should all match 'building 2'
+
+--echo # INTERSECTS
 set @point_text = 'POINT(90.0 90.0)';
 set @buffer_distance = 10;
 select name, ST_Area(GeometryFromWkb(wkb_geometry))
@@ -31,8 +34,35 @@ where ST_Intersects(
   GeometryFromWkb(wkb_geometry)
 );
 
+--echo # INTERSECTS, confirm pushdown in explain
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
+explain select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+  ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+  GeometryFromWkb(wkb_geometry)
+);
+
+--echo # OVERLAPS
+set @point_text = 'POINT(70.0 70.0)';
+set @buffer_distance = 25;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Overlaps(
+  ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+  GeometryFromWkb(wkb_geometry)
+);
+
+--echo # EQUALS
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_EQUALS(@g2, GeometryFromWkb(wkb_geometry));
+
 --echo # Test again, but without the spatial index
 --echo # (results should be identical, but without pushdown to _X _Y)
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
 set @mytile_enable_pushdown = false;
 select name, ST_Area(GeometryFromWkb(wkb_geometry))
 from t1

--- a/mysql-test/mytile/t/spatial_index.test
+++ b/mysql-test/mytile/t/spatial_index.test
@@ -1,0 +1,45 @@
+--echo # SPATIAL INDEX PUSHDOWN
+
+--echo # Create a test array 
+create table t1 (
+  _X           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  _Y           double DIMENSION=1 lower_bound="0" upper_bound="100" tile_extent="10",
+  name         varchar(255) filters="GZIP=-1",
+  wkb_geometry blob NOT NULL
+)
+engine=MyTile
+array_type='SPARSE'
+;
+
+--echo # Insert 2 polygon geometries
+set @g1 = GeometryFromText('POLYGON((10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0))');
+set @g2 = GeometryFromText('POLYGON((84.0 84.0, 94.0 84.0, 94.0 94.0, 84.0 94.0, 84.0 84.0))');
+set @bbox1 = ST_Centroid(ST_Envelope(@g1));
+set @bbox2 = ST_Centroid(ST_Envelope(@g2));
+insert into t1 (_X, _Y, name, wkb_geometry) values
+  (ST_X(@bbox1), ST_Y(@bbox1), "building1", aswkb(@g1)),
+  (ST_X(@bbox2), ST_Y(@bbox2), "building2", aswkb(@g2))
+;
+
+--echo # Test that only one intersects a search radius
+set @point_text = 'POINT(90.0 90.0)';
+set @buffer_distance = 10;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+  ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+  GeometryFromWkb(wkb_geometry)
+);
+
+--echo # Test again, but without the spatial index
+--echo # (results should be identical, but without pushdown to _X _Y)
+set @mytile_enable_pushdown = false;
+select name, ST_Area(GeometryFromWkb(wkb_geometry))
+from t1
+where ST_Intersects(
+  ST_Buffer(GeometryFromText(@point_text), @buffer_distance),
+  GeometryFromWkb(wkb_geometry)
+);
+
+set @mytile_enable_pushdown = true;
+drop table t1;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1623,7 +1623,7 @@ tile::mytile::cond_push_func_spatial(const Item_func *func_item,
                                      std::shared_ptr<tiledb::QueryCondition> &qcPtr) {
   DBUG_ENTER("tile::mytile::cond_push_func_spatial");
   Item **args = func_item->arguments();
-  bool neg = FALSE;
+//  bool neg = FALSE;
 
   // Find the geometry column name in order to identify valid operands
   std::string geometry_column = "wkb_geometry";
@@ -1717,15 +1717,21 @@ tile::mytile::cond_push_func_spatial(const Item_func *func_item,
     // Evaluate to native geometry type
     aoi->eval_const_cond();
     if (aoi->has_value()) {
-      // TODO I have no idea how to use the val_native* methods
-      Geometry *geom = nullptr;
-      const Type_handler_geometry *th= new Type_handler_geometry();
-      bool a = aoi->val_native_with_conversion_result(ha_thd(), dynamic_cast<Native *>(geom), th);
-      DBUG_ASSERT(a);
+      //    Geometry *geom = nullptr;
+
+      //    const Type_handler_geometry *th= new Type_handler_geometry();
+      //    bool a = aoi->val_native_with_conversion_result(ha_thd(), dynamic_cast<Native *>(geom), th); DBUG_ASSERT(a);
+      String arg_val;
+      String *swkb = aoi->val_str(&arg_val);
+      Geometry_buffer buffer;
+      Geometry *geom = NULL;
+
+      geom = Geometry::construct(&buffer, swkb->ptr(), swkb->length());
 
       // Calculate minimum bounding rectangle of geometry
       // TODO This Geometry is still not valid
       if (geom != nullptr) {
+        std::cout << "GEOMETRY VALID!" << std::endl;
         MBR mbr;
         const char *c_end;
         geom->get_mbr(&mbr, &c_end);
@@ -1733,6 +1739,8 @@ tile::mytile::cond_push_func_spatial(const Item_func *func_item,
         y1 = mbr.ymin;
         x2 = mbr.xmax;
         y2 = mbr.ymax;
+        std::cout << "MBR before padding: " << x1 << " " << y1 << " " << x2
+                  << " " << y2 << " " << std::endl;
       } else {
         std::cout << "ERROR! Geometry is not valid, using dummy mbr" << std::endl;
       }

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1665,11 +1665,10 @@ tile::mytile::cond_push_func_spatial(const Item_func *func_item,
     }
     case Item::FUNC_ITEM: {
       Item_func *f = dynamic_cast<Item_func *>(args[i]);
+      // Special case: Sentinel value used to signify the wkb attribute
       // Has to match the literal cast string e.g. "GeometryFromWkb(wkb_geometry)"
       if (f->full_name() == expected_cast) {
-        wkb_arg = i;
-      } else if (f->const_item() || f->const_during_execution()) {
-          aoi_arg = i;
+          wkb_arg = i;
       }
       break;
     }
@@ -1698,11 +1697,8 @@ tile::mytile::cond_push_func_spatial(const Item_func *func_item,
     double x2 = 0;
     double y2 = 0;
 
-    // TODO handle Item_func too
-    // TODO DRY we already do this dyncast in the switch statement above...
-    auto *aoi = dynamic_cast<Item_cache *>(args[aoi_arg]);
-
     // Evaluate to native geometry type
+    auto *aoi = dynamic_cast<Item_cache *>(args[aoi_arg]);
     aoi->eval_const_cond();
     if (aoi->has_value()) {
       String arg_val;

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -271,6 +271,15 @@ public:
                              std::shared_ptr<tiledb::QueryCondition> &qcPtr);
 
   /**
+   *  Handle spatial condition pushdowns
+   * @param func_item
+   * @param qcPtr
+   * @return
+   */
+  const COND *cond_push_func_spatial(const Item_func *func_item,
+                             std::shared_ptr<tiledb::QueryCondition> &qcPtr);
+
+  /**
    * Handle datetiem function pushdowns
    * @param func_item
    * @param qcPtr

--- a/mytile/mytile.cc
+++ b/mytile/mytile.cc
@@ -68,9 +68,11 @@ tiledb_datatype_t tile::mysqlTypeToTileDBType(int type, bool signedInt) {
   case MYSQL_TYPE_BLOB:
   case MYSQL_TYPE_LONG_BLOB:
   case MYSQL_TYPE_MEDIUM_BLOB:
-  case MYSQL_TYPE_TINY_BLOB:
+  case MYSQL_TYPE_TINY_BLOB: {
+    return tiledb_datatype_t::TILEDB_BLOB;
+  }
+
   case MYSQL_TYPE_ENUM: {
-    // TODO: We really should differentiate between blobs and text fields
     return tiledb_datatype_t::TILEDB_CHAR;
   }
 
@@ -418,7 +420,7 @@ bool tile::TileDBDateTimeType(tiledb_datatype_t type) {
 }
 
 /**
- * Returns if a mysql tpye is a blob
+ * Returns if a mysql type is a blob
  * @param type
  * @return
  */


### PR DESCRIPTION
Changes:
- Adds a `cond_push_func_spatial` function to handle  `ST_Intersection` and similar spatial functions, which adds a range pushdown to `_X` and `_Y` dimensions. See [paper doc](https://www.dropbox.com/scl/fi/pd36ldxrh7lz1p08km6so/MariaDB-Spatial-SQL.paper?dl=0&rlkey=nvkvcvaqqmu2zgy0drz2x6czs) for more details.
- Map the MySQL Blob types to TILEDB_BLOB. This enables creation of blob attributes with CREATE SQL statements (previously resulting in char).