### PR TITLE
add support for ALTER TABLE ADD/DROP

### DIFF
--- a/mysql-test/mytile/r/schema_evolution.result
+++ b/mysql-test/mytile/r/schema_evolution.result
@@ -1,0 +1,38 @@
+#
+# The purpose of this test is to validate the schema evolution functionality
+#
+CREATE TABLE `evol` (
+`id` int dimension=1 `lower_bound`="-10000" `upper_bound`="100000000" tile_extent="1",
+`a1` int filters='GZIP=6',
+`a2` int default null,
+`a3` varchar(255) default null,
+`a4` varchar(255) not null,
+PRIMARY KEY(id)
+) ENGINE=MyTile;
+INSERT INTO evol VALUES (1, 1, 1, "1", "1"), (2, 2, NULL, NULL, "2"), (3, 300, 300, "abc", "def");
+INSERT INTO evol VALUES (1, 1, 10, "beef", "stew"), (2, 100, NULL, "test", "orange"), (3, 300, 400, "def", "beef");
+SELECT * FROM evol;
+id	a1	a2	a3	a4
+1	1	10	beef	stew
+2	100	NULL	test	orange
+3	300	400	def	beef
+ALTER TABLE `evol` DROP `a3`;
+select * from evol;
+id	a1	a2	a4
+1	1	10	stew
+2	100	NULL	orange
+3	300	400	beef
+ALTER TABLE `evol` ADD COLUMN (`a10` int filters='GZIP=6');
+ALTER TABLE `evol` ADD COLUMN (`a30` varchar(255));
+select * from evol;
+id	a1	a2	a4	a10	a30
+1	1	10	stew	NULL	NULL
+2	100	NULL	orange	NULL	NULL
+3	300	400	beef	NULL	NULL
+INSERT INTO evol VALUES (1, 1, 10, "stew", 10, "a"), (2, 100, NULL, "orange", 20, "b"), (3, 300, 400, "beef", 30, "c");
+select * from evol;
+id	a1	a2	a4	a10	a30
+1	1	10	stew	10	a
+2	100	NULL	orange	20	b
+3	300	400	beef	30	c
+DROP TABLE evol;

--- a/mysql-test/mytile/t/schema_evolution.test
+++ b/mysql-test/mytile/t/schema_evolution.test
@@ -1,0 +1,23 @@
+--echo #
+--echo # The purpose of this test is to validate the schema evolution functionality
+--echo #
+CREATE TABLE `evol` (
+  `id` int dimension=1 `lower_bound`="-10000" `upper_bound`="100000000" tile_extent="1",
+  `a1` int filters='GZIP=6',
+  `a2` int default null,
+  `a3` varchar(255) default null,
+  `a4` varchar(255) not null,
+  PRIMARY KEY(id)
+) ENGINE=MyTile;
+INSERT INTO evol VALUES (1, 1, 1, "1", "1"), (2, 2, NULL, NULL, "2"), (3, 300, 300, "abc", "def");
+INSERT INTO evol VALUES (1, 1, 10, "beef", "stew"), (2, 100, NULL, "test", "orange"), (3, 300, 400, "def", "beef");
+SELECT * FROM evol;
+ALTER TABLE `evol` DROP `a3`;
+select * from evol;
+ALTER TABLE `evol` ADD COLUMN (`a10` int filters='GZIP=6');
+ALTER TABLE `evol` ADD COLUMN (`a30` varchar(255));
+select * from evol;
+INSERT INTO evol VALUES (1, 1, 10, "stew", 10, "a"), (2, 100, NULL, "orange", 20, "b"), (3, 300, 400, "beef", 30, "c");
+select * from evol;
+DROP TABLE evol;
+

--- a/mytile/ha_mytile.h
+++ b/mytile/ha_mytile.h
@@ -170,6 +170,22 @@ public:
   int close(void) override;
 
   /**
+   * alter array
+   * @param altered_table
+   * @param ha_alter_info
+   * @return
+   */
+  bool inplace_alter_table(TABLE* altered_table, Alter_inplace_info* ha_alter_info) override;
+
+  /**
+   * Check if alter operation is supported
+   * @param altered_table
+   * @param ha_alter_info
+   * @return
+   */
+  enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *altered_table, Alter_inplace_info *ha_alter_info) override;
+
+  /**
    * Initialize table scanning
    * @return
    */
@@ -653,6 +669,36 @@ private:
   // We default to 100000 so that if we don't compute it, MariaDB still avoid
   // optimizations for small tables
   uint64_t records_upper_bound = 100000;
+
+  /**
+   * Checks if two fields have the same name
+   * @param a field a
+   * @param b field b
+   * @return true if yes
+   */
+  bool fields_have_same_name(Field* a, Field* b);
+
+  /**
+   * Finds which columns to add by comparing the new with the old schema
+   *
+   * @param new_table the new table schema
+   * @param orig_table the original table schema
+   * @param context The context
+   * @param columns_to_be_added a vector with the attributes that need to be added
+   */
+  void find_columns_to_add(TABLE *new_table, TABLE *orig_table,
+                           tiledb::Context context,
+                           std::vector<tiledb::Attribute>& columns_to_be_added);
+
+  /**
+   * Finds which columns have been dropped by comparing the new with the old schema
+   *
+   * @param new_table the new table schema
+   * @param orig_table the original table schema
+   * @param columns_to_be_dropped a vector of strings with the col names to drop
+   */
+  void find_columns_to_drop(TABLE *new_table, TABLE *orig_table,
+                            std::vector<std::string>& columns_to_be_dropped);
 
   /**
    * Helper to setup writes


### PR DESCRIPTION
This PR adds support for the ```ALTER TABLE ADD/DROP``` operations in MyTile by using the ```SchemaEvolution``` API. All other requests will return an error message.

Users can now drop one or more columns by name:
```ALTER TABLE `table` DROP `a3`, DROP `a4`;```

Or add new attributes and configure them the same way they do when they use ```CREATE_TABLE```
```ALTER TABLE `table` ADD COLUMN (`a10` int filters='GZIP=6');```

[sc-30285]
