### PR TITLE
updating ubuntu image to ```ubuntu-latest``` for nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-13", "ubuntu-20.04"]
+        os: ["macos-13", "ubuntu-22.04"]
     env:
       OWNER_TILEDB_MARIADB: ${{ github.repository_owner }} # support building from a fork
       REF_MARIADB: mariadb-10.6.10

--- a/scripts/nightly/setup-ubuntu.sh
+++ b/scripts/nightly/setup-ubuntu.sh
@@ -4,6 +4,8 @@ set -eux
 # Install dependencies on Ubuntu
 
 apt-get update
+
+g++ --version
 apt-get install --yes \
   bison \
   gdb \


### PR DESCRIPTION
This compilation error was caused because we were using gcc 9. I have updated the nightly script to use ```ubuntu-22.04``` which uses gcc 11. I think it's better than manually updating the gcc in the older image. 