### PR TITLE
Fix mysqld crash on Macos

### DIFF
--- a/mytile/mytile-statusvars.cc
+++ b/mytile/mytile-statusvars.cc
@@ -51,6 +51,7 @@ static int show_tiledb_version(MYSQL_THD thd, struct st_mysql_show_var *var,
 
 struct st_mysql_show_var mytile_status_variables[] = {
     {"mytile_tiledb_version", (char *)show_tiledb_version, SHOW_SIMPLE_FUNC},
+    {NullS, NullS, SHOW_LONG} 
 };
 } // namespace statusvars
 } // namespace tile


### PR DESCRIPTION
The exported status variables array should end with a null-like struct, the absence of that final null-like struct causes mysqld to crash on macos.
@Shelnutt2 I've mentioned this to you when I last debugged something in mytile, but back then I just worked around and moved on.