### PR TITLE
Set backup value of TILEDB_FORCE_ALL_DEPS to OFF in nightly build

### DIFF
--- a/scripts/nightly/build-tiledb-mariadb.sh
+++ b/scripts/nightly/build-tiledb-mariadb.sh
@@ -40,7 +40,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Debug \
   -DWITH_DEBUG=1 \
   -DCMAKE_INCLUDE_PATH="/usr/local/include" \
-  -DTILEDB_FORCE_ALL_DEPS=${TILEDB_FORCE_ALL_DEPS-NO} \
+  -DTILEDB_FORCE_ALL_DEPS=${TILEDB_FORCE_ALL_DEPS-OFF} \
   ..
 make -j2
 ./mysql-test/mysql-test-run.pl --suite=mytile --debug


### PR DESCRIPTION
The CMake variable `TILEDB_FORCE_ALL_DEPS` should be set to `ON` or `OFF`. I accidentally had the backup value set to `NO`

This change will have no immediate effect since I set the env var `TILEDB_FORCE_ALL_DEPS` in the nightly workflow file:

https://github.com/TileDB-Inc/TileDB-MariaDB/blob/cacc61994e2b9b9a37387eea2bfc14220c375cc4/.github/workflows/nightly.yaml#L23