### PR TITLE
Fix secret passing between workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,6 +4,11 @@ name: docker
 # TODO: Or make this take a list of tags... Sadly this cannot be done now, only string can be passed
 on:
   workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -43,3 +43,4 @@ jobs:
     needs: build
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref_name == github.event.repository.default_branch }}
     uses: ./.github/workflows/docker.yaml
+    secrets: inherit


### PR DESCRIPTION
This PR should fix the issue with `docker-login` action not being able to see secrets.

Tested with custom dockerhub account: https://github.com/dudoslav/TileDB-MariaDB/actions/runs/7244763800/job/19733614867
Note that this pipeline fails because of Dockerfile using hard coded links for THIS repo.