### PR TITLE
Add superbuild configuration into CI/CD stable matrix

### DIFF
--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-13", "ubuntu-22.04"]
+        superbuild: [true, false]
     env:
       OWNER_TILEDB_MARIADB: ${{ github.repository_owner }} # support building from a fork
       REF_MARIADB: mariadb-11.0.2
@@ -36,6 +37,7 @@ jobs:
         if: runner.os == 'macOS'
         run: bash scripts/ci/setup-macos.sh
       - name: Build libtiledb
+        if: ${{ matrix.superbuild }}
         run: bash scripts/ci/build-libtiledb.sh
       - name: Build TileDB-MariaDB
         run: bash scripts/ci/build-tiledb-mariadb.sh

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    name: stable-${{ matrix.os }}
+    name: stable-${{ matrix.os }}-${{ matrix.superbuild && "superbuild" || "default" }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    name: stable-${{ matrix.os }}-${{ matrix.superbuild && "superbuild" || "default" }}
+    name: stable-${{ matrix.os }}-${{ matrix.superbuild && 'superbuild' || 'default' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         os: ["macos-13", "ubuntu-22.04"]
         superbuild: [true, false]
+        exclude:
+          - os: "macos-13"
+            superbuild: true
     env:
       OWNER_TILEDB_MARIADB: ${{ github.repository_owner }} # support building from a fork
       REF_MARIADB: mariadb-11.0.2
@@ -37,7 +40,7 @@ jobs:
         if: runner.os == 'macOS'
         run: bash scripts/ci/setup-macos.sh
       - name: Build libtiledb
-        if: ${{ matrix.superbuild }}
+        if: ${{ ! matrix.superbuild }}
         run: bash scripts/ci/build-libtiledb.sh
       - name: Build TileDB-MariaDB
         run: bash scripts/ci/build-tiledb-mariadb.sh


### PR DESCRIPTION
This PR adds superbuild variant into CI/CD matrix for Linux platform only, since the Mac OS superbuild does not work yet.