### PR TITLE
pin cmake to 3.29.0

### DIFF
--- a/scripts/ci/setup-macos.sh
+++ b/scripts/ci/setup-macos.sh
@@ -8,7 +8,6 @@ brew install \
   automake \
   bison@2.7 \
   boost \
-  cmake \
   gnutls \
   jemalloc \
   m4 \


### PR DESCRIPTION
Removing cmake from the ```brew install``` list prevents it from being upgraded to 3.29.1 as the runners currently have 3.29.0 installed. We will have a fix for core by the time the runners upgrade to cmake 3.29.1 so there is no need to file a follow-up story here. 

Nightly:

https://github.com/TileDB-Inc/TileDB-MariaDB/actions/runs/8603000565/job/23573846830