### PR TITLE
Migrate GitHub Actions to Node 20

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
           - dockerfile: "Dockerfile-R"
             repository: "tiledb/tiledb-mariadb-r"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,7 +29,7 @@ jobs:
       TILEDB_FORCE_ALL_DEPS: OFF
     steps:
       # This initial checkout is only to obtain the CI scripts
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clone and checkout repos
         run: bash scripts/ci/checkout.sh
       - name: Setup Ubuntu
@@ -49,7 +49,7 @@ jobs:
     needs: build
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -30,7 +30,7 @@ jobs:
       TILEDB_FORCE_ALL_DEPS: OFF
     steps:
       # This initial checkout is only to obtain the CI scripts
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clone and checkout repos
         run: bash scripts/ci/checkout.sh
       - name: Setup Ubuntu


### PR DESCRIPTION
https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/