### PR TITLE
fix Dockerfile download links

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,8 @@ jobs:
             repository: "tiledb/tiledb-mariadb-min"
           - dockerfile: "Dockerfile-server"
             repository: "tiledb/tiledb-mariadb-server"
+          - dockerfile: "Dockerfile-R"
+            repository: "tiledb/tiledb-mariadb-r"
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,8 +22,6 @@ jobs:
             repository: "tiledb/tiledb-mariadb-min"
           - dockerfile: "Dockerfile-server"
             repository: "tiledb/tiledb-mariadb-server"
-          - dockerfile: "Dockerfile-R"
-            repository: "tiledb/tiledb-mariadb-r"
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN cp /tmp/mytile/docker/init.sh /tmp/init.sh
 ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
 ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
 
-RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
   && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
   && cd ${MARIADB_VERSION} \
@@ -103,8 +103,7 @@ RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${
   && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
-  && cp -r storage/mytile/externals/install/include/tiledb/ /usr/include/tiledb/ \
-  && cp -r storage/mytile/externals/install/lib/libtiledb.so* /usr/lib/ \
+  && cp -r storage/mytile/externals/install/* /usr \
   && cd ../../ \
   && rm -r ${MARIADB_VERSION}
 

--- a/docker/Dockerfile-R
+++ b/docker/Dockerfile-R
@@ -110,17 +110,16 @@ RUN cp /tmp/mytile/docker/init.sh /tmp/init.sh
 ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
 ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
 
-RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
   && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
   && cd ${MARIADB_VERSION} \
   && mkdir builddir \
   && cd builddir \
-  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_INNOBASE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=ON -DCMAKE_INSTALL_PREFIX=/opt/server .. \
+  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_INNOBASE=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=ON -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
-  && cp -r storage/mytile/externals/install/include/tiledb/ /usr/include/tiledb/ \
-  && cp -r storage/mytile/externals/install/lib/libtiledb.so* /usr/lib/ \
+  && cp -r storage/mytile/externals/install/* /usr \
   && cd ../../ \
   && rm -r ${MARIADB_VERSION}
 

--- a/docker/Dockerfile-R
+++ b/docker/Dockerfile-R
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 LABEL maintainer="support@tiledb.io"
 
 ENV AWS_EC2_METADATA_DISABLED true
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
   libncurses5-dev \
   libpam0g-dev \
   libpcre3-dev \
+  libreadline-gplv2-dev \
   libstemmer-dev \
   libssl-dev \
   libnuma-dev \
@@ -45,15 +46,6 @@ RUN apt-get update && apt-get install -y \
   git \
   wget \
   libcurl4-openssl-dev \
-  apt-transport-https \
-  ca-certificates \
-  gnupg \
-  gpg \
-  pkg-config \
-  curl \
-  zip \
-  unzip \
-  tar \
   software-properties-common \
   dirmngr \
   libcurl4 \
@@ -101,6 +93,12 @@ RUN groupadd -r mysql && useradd -r -g mysql mysql
 RUN git config --global user.email "you@example.com" \
  && git config --global user.name "Your Name"
 
+# Install tiledb
+RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
+ && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
+ && rm  ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
+
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \
  && cp /tmp/mytile/docker/docker-entrypoint-interactive.sh /usr/local/bin/docker-entrypoint-interactive.sh
@@ -116,10 +114,9 @@ RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSIO
   && cd ${MARIADB_VERSION} \
   && mkdir builddir \
   && cd builddir \
-  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_INNOBASE=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=ON -DCMAKE_INSTALL_PREFIX=/opt/server .. \
+  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_INNOBASE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=ON -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
-  && cp -r storage/mytile/externals/install/* /usr \
   && cd ../../ \
   && rm -r ${MARIADB_VERSION}
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -89,7 +89,7 @@ RUN cp /tmp/mytile/docker/init.sh /tmp/init.sh
 ENV CFLAGS "${CFLAGS} -Wno-error=noexcept-type -Wno-error=deprecated-declarations"
 ENV CXXFLAGS "${CXXFLAGS} -Wno-error=noexcept-type -Wno-error=deprecated-declarations"
 
-RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
   && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
   && cd ${MARIADB_VERSION} \
@@ -98,8 +98,7 @@ RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${
   && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=DEBUG -SWITH_DEBUG=1 -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
-  && cp -r storage/mytile/externals/install/include/tiledb/ /usr/include/tiledb/ \
-  && cp -r storage/mytile/externals/install/lib/libtiledb.so* /usr/lib/ \
+  && cp -r storage/mytile/externals/install/* /usr \
   && cd ../../ \
   && rm -r ${MARIADB_VERSION}
 

--- a/docker/Dockerfile-min
+++ b/docker/Dockerfile-min
@@ -98,7 +98,7 @@ RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
 ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
 ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
 
-RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
  && tar xf ${MARIADB_VERSION}.tar.gz \
  && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
  && cd ${MARIADB_VERSION} \

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -99,7 +99,7 @@ RUN apt-get update && apt-get install -y \
 ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
 ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
 
-RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
   && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
   && cd ${MARIADB_VERSION} \
@@ -108,8 +108,7 @@ RUN wget https://downloads.mariadb.org/interstitial/${MARIADB_VERSION}/source/${
   && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
-  && cp -r storage/mytile/externals/install/include/tiledb/ /usr/include/tiledb/ \
-  && cp -r storage/mytile/externals/install/lib/libtiledb.so* /usr/lib/ \
+  && cp -r storage/mytile/externals/install/* /usr \
   && cd ../../ \
   && rm -r ${MARIADB_VERSION}
 


### PR DESCRIPTION
This PR will fix the main branch failures. The introduction of #346 is causing failures in the Dockerfile-R. The failures have to do with the fact the this is the only file that builds mariadb in "embedded" mode. This dockefile is not used anymore so it is removed by this PR. In addition to that, the download links for mariadb have been updated.

A successful run can be seen here https://github.com/DimitrisStaratzis/TileDB-MariaDB/actions/runs/9758760985/job/26934249792. The failures are because of the docker hub credentials. the images are built fine. 

[sc-50453]