### PR TITLE
Fix combining multiple operators

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1989,7 +1989,7 @@ const COND *tile::mytile::cond_push_cond(Item_cond *cond_item) {
               std::make_shared<tiledb::QueryCondition>(*queryCondition);
         } else {
           tiledb::QueryCondition tempCondition =
-              queryCondition->combine(*operatorCondition, op);
+              queryCondition->combine(*queryCondition, op);
           operatorCondition =
               std::make_shared<tiledb::QueryCondition>(tempCondition);
         }


### PR DESCRIPTION
This fixes a typo in combinding multiple operators to use `queryCondition` instead of `operatorCondition`.