### PR TITLE
Algorithm bug fix for AND/OR

### DIFF
--- a/mysql-test/mytile/r/pushdown_two_predicates.result
+++ b/mysql-test/mytile/r/pushdown_two_predicates.result
@@ -51,3 +51,18 @@ select * from t1 where d1=2 and d2=2;
 d1	d2	a
 2	2	6
 DROP TABLE t1;
+# Test combination of dims and attributes
+create table t2 (
+X  double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+Y  double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+a integer NOT NULL
+) engine=MyTile array_type='SPARSE';
+INSERT INTO t2 (X, Y, a) VALUES (0, 1, 2);
+INSERT INTO t2 (X, Y, a) VALUES (1, 1, 3);
+INSERT INTO t2 (X, Y, a) VALUES (2, 1, 4);
+INSERT INTO t2 (X, Y, a) VALUES (3, 1, 5);
+select * from t2 where X > 0 and a > 3;
+X	Y	a
+2	1	4
+3	1	5
+DROP TABLE t2;

--- a/mysql-test/mytile/t/pushdown_two_predicates.test
+++ b/mysql-test/mytile/t/pushdown_two_predicates.test
@@ -29,3 +29,17 @@ select * from t1;
 select * from t1 where d1=2;
 select * from t1 where d1=2 and d2=2;
 DROP TABLE t1;
+
+--echo # Test combination of dims and attributes
+create table t2 (
+X  double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+Y  double DIMENSION=1 lower_bound="0" upper_bound="120" tile_extent="10",
+a integer NOT NULL
+) engine=MyTile array_type='SPARSE';
+
+INSERT INTO t2 (X, Y, a) VALUES (0, 1, 2);
+INSERT INTO t2 (X, Y, a) VALUES (1, 1, 3);
+INSERT INTO t2 (X, Y, a) VALUES (2, 1, 4);
+INSERT INTO t2 (X, Y, a) VALUES (3, 1, 5);
+select * from t2 where X > 0 and a > 3;
+DROP TABLE t2;

--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -1982,7 +1982,7 @@ const COND *tile::mytile::cond_push_cond(Item_cond *cond_item) {
       // Dimensions do not support QCs, hence the queryCondition ptr
       // returned from cond_push_local() will be null, so skip
       if (queryCondition != nullptr) {
-        if (i == 0) {
+        if (operatorCondition == nullptr) {
           // if we are dealing with the first qc of this multi-predicate
           // operator, we need to initialize
           operatorCondition =


### PR DESCRIPTION
Fixes a bug that when in a combined condition we were combining a dim and an attribute and the dim was first. 

E.g. ```select * from array where d1 > 3 and a > 4```

Without the fix the query could work by reversing the order:

E.g. ```select * from array where a > 4 and d1 > 3```