### PR TITLE
Use built-in config equality operator.

### DIFF
--- a/mytile/ha_mytile.cc
+++ b/mytile/ha_mytile.cc
@@ -794,7 +794,7 @@ int tile::mytile::create(const char *name, TABLE *table_arg,
     cfg["sm.encryption_key"] = encryption_key.c_str();
   }
 
-  if (!compare_configs(cfg, this->config)) {
+  if (cfg != this->config) {
     this->config = cfg;
     this->ctx = build_context(this->config);
   }
@@ -819,7 +819,7 @@ int tile::mytile::open(const char *name, int mode, uint test_if_locked) {
     cfg["sm.encryption_key"] = encryption_key.c_str();
   }
 
-  if (!compare_configs(cfg, this->config)) {
+  if (cfg != this->config) {
     this->config = cfg;
     this->ctx = build_context(this->config);
   }
@@ -3433,7 +3433,7 @@ void tile::mytile::open_array_for_reads(THD *thd) {
     // First rebuild context with new config if needed
     tiledb::Config cfg = build_config(ha_thd());
 
-    if (!compare_configs(cfg, this->config)) {
+    if (cfg != this->config) {
       this->config = cfg;
       this->ctx = build_context(this->config);
     }
@@ -3532,7 +3532,7 @@ void tile::mytile::open_array_for_writes(THD *thd) {
     // First rebuild context with new config if needed
     tiledb::Config cfg = build_config(ha_thd());
 
-    if (!compare_configs(cfg, this->config)) {
+    if (cfg != this->config) {
       this->config = cfg;
       this->ctx = build_context(this->config);
     }

--- a/mytile/utils.cc
+++ b/mytile/utils.cc
@@ -55,27 +55,6 @@ std::vector<std::string> tile::split(const std::string &str, char delim) {
   return res;
 }
 
-/**
- * compares two config
- * @param rhs
- * @param lhs
- * @return true is identical, false otherwise
- */
-bool tile::compare_configs(tiledb::Config &rhs, tiledb::Config &lhs) {
-  // Check every parameter to see if they are the same or different
-  for (auto &it : rhs) {
-    try {
-      if (lhs.get(it.first) != it.second) {
-        return false;
-      }
-    } catch (tiledb::TileDBError &e) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 bool tile::is_numeric_type(const tiledb_datatype_t &datatype) {
   switch (datatype) {
   case TILEDB_INT8:

--- a/mytile/utils.h
+++ b/mytile/utils.h
@@ -122,14 +122,6 @@ tiledb::Config build_config(THD *thd);
 tiledb::Context build_context(tiledb::Config &cfg);
 
 /**
- * compares two config
- * @param rhs
- * @param lhs
- * @return true is identical, false otherwise
- */
-bool compare_configs(tiledb::Config &rhs, tiledb::Config &lhs);
-
-/**
  * Log errors only if log level is set to error or higher
  * @param thd thd to get log level from
  * @param msg message to log


### PR DESCRIPTION
The TileDB C++ API provides an [equality operator for configs](https://github.com/TileDB-Inc/TileDB/blob/5cee0cad1836d6a42ed39eb5a50875b07276d8fa/tiledb/sm/cpp_api/config.h#L241-L252). Use that instead of the `compare_configs` utility function.