### PR TITLE
Reduce nightly builds to once a week

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/nightly.yaml'
       - 'scripts/ci/**'
   schedule:
-    - cron: "0 2 * * *" # Every night at 2 AM UTC (9 PM EST; 10 PM EDT)
+    - cron: "0 2 * * 0" # Every Sunday night at 2 AM UTC (9 PM EST; 10 PM EDT)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Given the following:

* This repository isn't being actively developed
* Its deprecation has been announced (#390)
* The nightly CI requires a total of 90 minutes

I propose we reduce the nightly builds to only run [every Sunday night](https://crontab.guru/#0_2_*_*_0).

xref: #391 