### PR TITLE
Update dockerfiles dev and min to core 2.29.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 mysql-test/mytile/r/*.reject
 mysql-test/mytile/my.cnf
+
+.idea/

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -46,30 +46,16 @@ RUN apt-get update && apt-get install -y \
   git \
   wget \
   libcurl4-openssl-dev \
+  libcurl4 \
   && rm -rf /var/lib/apt/lists/*
 
 ENV MTR_MEM /tmp
-
-WORKDIR /tmp
-
-ENV MARIADB_VERSION="mariadb-11.0.2"
-
-ARG MYTILE_VERSION="0.37.0"
 
 ARG TILEDB_VERSION="2.29.1"
 ARG TILEDB_VERSION_SHORT_SHA="9a6284d"
 ARG TILEDB_PREBUILT_FILE="tiledb-linux-x86_64-${TILEDB_VERSION}-${TILEDB_VERSION_SHORT_SHA}.tar.gz"
 
-# Download mytile release
-RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
-  && tar xf /tmp/${MYTILE_VERSION}.tar.gz \
-  && mv TileDB-MariaDB-${MYTILE_VERSION} mytile
-
-# Copy example arrays to opt
-RUN cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mysql && useradd -r -g mysql mysql
+WORKDIR /tmp
 
 # Set git config so superbuild of tiledb can cherry-pick capnp fix
 RUN git config --global user.email "you@example.com" \
@@ -78,8 +64,18 @@ RUN git config --global user.email "you@example.com" \
 # Install tiledb
 RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
  && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
- && rm ${TILEDB_PREBUILT_FILE} \
+ && rm  ${TILEDB_PREBUILT_FILE} \
  && ldconfig
+
+ENV MARIADB_VERSION="mariadb-11.0.2"
+
+ADD . /tmp/mytile
+
+# Copy example arrays to opt
+RUN cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r mysql && useradd -r -g mysql mysql
 
 RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
  && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \
@@ -87,14 +83,8 @@ RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
 
 RUN cp /tmp/mytile/docker/init.sh /tmp/init.sh
 
-# Install curl after building tiledb
-RUN apt-get update && apt-get install -y \
-  libcurl4 \
-  libcurl4-openssl-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
-ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
+ENV CFLAGS "${CFLAGS} -Wno-error=noexcept-type -Wno-error=deprecated-declarations"
+ENV CXXFLAGS "${CXXFLAGS} -Wno-error=noexcept-type -Wno-error=deprecated-declarations"
 
 RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
   && tar xf ${MARIADB_VERSION}.tar.gz \
@@ -102,7 +92,7 @@ RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSIO
   && cd ${MARIADB_VERSION} \
   && mkdir builddir \
   && cd builddir \
-  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -SWITH_DEBUG=0 -DBUILD_CONFIG=mysql_release -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
+  && cmake -DPLUGIN_INNODB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=DEBUG -SWITH_DEBUG=1 -DWITH_EMBEDDED_SERVER=OFF -DCMAKE_INSTALL_PREFIX=/opt/server .. \
   && make -j$(nproc) \
   && make install \
   && cd ../../ \
@@ -142,6 +132,11 @@ RUN chown -R mysql:mysql /var/log/mysql
 RUN chown -R mysql:mysql /opt/server
 
 RUN chown -R mysql:mysql /opt/tiledb_arrays
+
+# Set defaults for initializing the server
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
+
+ENV MYSQL_DATABASE=test
 
 # Set paths needed for bitnami helm mariadb
 RUN mkdir /opt/bitnami

--- a/docker/Dockerfile-min
+++ b/docker/Dockerfile-min
@@ -1,0 +1,145 @@
+FROM ubuntu:20.04 AS builder
+LABEL maintainer="support@tiledb.io"
+
+ENV AWS_EC2_METADATA_DISABLED=true \
+ DEBIAN_FRONTEND=noninteractive \
+ TZ=GMT
+
+RUN apt-get update \
+ && apt-get install -y \
+ gosu \
+ pwgen \
+ tzdata \
+ gcc \
+ g++ \
+ build-essential \
+ libasan5 \
+ bison \
+ chrpath \
+ cmake \
+ gdb \
+ gnutls-dev \
+ libaio-dev \
+ libboost-dev \
+ libdbd-mysql \
+ libjudy-dev \
+ libncurses5-dev \
+ libpam0g-dev \
+ libpcre3-dev \
+ libreadline-gplv2-dev \
+ libstemmer-dev \
+ libssl-dev \
+ libnuma-dev \
+ libxml2-dev \
+ lsb-release \
+ perl \
+ psmisc \
+ zlib1g-dev \
+ libcrack2-dev \
+ cracklib-runtime \
+ libjemalloc-dev \
+ libsnappy-dev \
+ liblzma-dev \
+ libzmq3-dev \
+ uuid-dev \
+ ccache \
+ git \
+ wget \
+ libcurl4-openssl-dev \
+ libcurl4 \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV MTR_MEM=/tmp \
+ MARIADB_VERSION="mariadb-11.0.2"
+WORKDIR /tmp
+
+ARG MYTILE_VERSION="0.37.0"
+
+ARG TILEDB_VERSION="2.29.1"
+ARG TILEDB_VERSION_SHORT_SHA="9a6284d"
+ARG TILEDB_PREBUILT_FILE="tiledb-linux-x86_64-${TILEDB_VERSION}-${TILEDB_VERSION_SHORT_SHA}.tar.gz"
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+# Set git config so superbuild of tiledb can cherry-pick capnp fix
+RUN groupadd -r mysql && useradd -r -g mysql mysql \
+ && git config --global user.email "you@example.com" \
+ && git config --global user.name "Your Name"
+
+RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \
+ && tar xf /tmp/${MYTILE_VERSION}.tar.gz \
+ && mv TileDB-MariaDB-${MYTILE_VERSION} mytile
+
+# Copy example arrays to opt
+RUN cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
+
+# Install tiledb
+RUN wget https://github.com/TileDB-Inc/TileDB/releases/download/${TILEDB_VERSION}/${TILEDB_PREBUILT_FILE} \
+ && tar xf ${TILEDB_PREBUILT_FILE} -C /usr \
+ && rm  ${TILEDB_PREBUILT_FILE} \
+ && ldconfig
+
+# TODO change branch after release cut
+#RUN git clone https://github.com/TileDB-Inc/TileDB-MariaDB.git -b ${MYTILE_VERSION} mytile \
+# && mkdir build_deps && cd build_deps \
+# && make -j$(nproc) \
+# && make -C tiledb install \
+# && cd /tmp \
+# && rm -rf build_deps
+
+RUN cp /tmp/mytile/docker/my.cnf /etc/mysql/my.cnf \
+ && cp /tmp/mytile/docker/mytile.cnf /etc/mysql/conf.d/mytile.cnf \
+ && cp /tmp/mytile/docker/setup-mariadb.sh /usr/local/bin/setup-mariadb.sh \
+ && cp -r /tmp/mytile/mysql-test/mytile/test_data/tiledb_arrays /opt/
+
+ENV CXXFLAGS="${CXXFLAGS} -Wno-error=deprecated-declarations"
+ENV CFLAGS="${CFLAGS} -Wno-error=deprecated-declarations"
+
+RUN wget https://archive.mariadb.org//${MARIADB_VERSION}/source/${MARIADB_VERSION}.tar.gz \
+ && tar xf ${MARIADB_VERSION}.tar.gz \
+ && mv /tmp/mytile ${MARIADB_VERSION}/storage/mytile \
+ && cd ${MARIADB_VERSION} \
+ && mkdir builddir \
+ && cd builddir \
+ && cmake -DCMAKE_INSTALL_PREFIX=/opt/server -DWITH_EMBEDDED_SERVER=OFF -DPLUGIN_INNODB=NO -DPLUGIN_INNOBASE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_SPHINX=NO -DPLUGIN_FEDERATED=NO -DPLUGIN_FEDERATEDX=NO -DPLUGIN_CONNECT=NO -DCMAKE_BUILD_TYPE=Release -DPLUGIN_MYTILE=YES .. \
+ && make -j$(nproc) \
+ && make install \
+ && cd /tmp \
+ && rm -rf ${MARIADB_VERSION} \
+ && rm -rf /opt/server/mysql-test/
+
+FROM ubuntu:20.04
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/bin/killall /usr/bin/killall
+COPY --from=builder /usr/include/tiledb /usr/include/tiledb
+COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=builder /usr/lib/libtiledb.so* /usr/lib/
+COPY --from=builder /opt/server /opt/server
+COPY --from=builder /opt/tiledb_arrays /opt/tiledb_arrays
+COPY --from=builder /etc /etc
+
+RUN set -ex \
+ && sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf /etc/mysql/conf.d/* \
+ && rm -rf /var/lib/mysql \
+ && mkdir -p /var/lib/mysql /var/run/mysqld \
+ && chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+ && chmod 777 /var/run/mysqld \
+ && find /etc/mysql/ -name '*.cnf' -print0 | xargs -0 grep -lZE '^(bind-address|log)' | xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+ && echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+
+ENV PATH="${PATH}:/opt/server/bin:/opt/server/scripts" \
+ MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+ MYSQL_DATABASE=test 
+
+RUN mkdir /var/log/mysql \
+ && chown -R mysql:mysql /var/lib/mysql \
+ && chown -R mysql:mysql /var/log/mysql \
+ && chown -R mysql:mysql /opt/server \
+ && chmod +x /usr/local/bin/setup-mariadb.sh
+
+USER mysql
+
+RUN /usr/local/bin/setup-mariadb.sh
+VOLUME /var/lib/mysql 
+EXPOSE 3306
+
+CMD ["/opt/server/bin/mariadbd", "--datadir=/var/lib/mysql"]


### PR DESCRIPTION
Rest server uses `tiledb/tiledb-mariadb-min:0.37.0`, but this Dockerfile deleted on tag 0.37.0 

```
tiledb.cloud.tiledb_cloud_error.TileDBCloudError: failed to pull image: Error response from daemon: manifest for tiledb/tiledb-mariadb-min:0.37.0 not found: manifest unknown: manifest unknown - Code: 5010 - Extra details: {'request_id': '3aa6b34f-019f-4f70-8dba-68c91d213480'}
```